### PR TITLE
Add UI to change verification grid size

### DIFF
--- a/src/components/media-controls/media-controls.ts
+++ b/src/components/media-controls/media-controls.ts
@@ -334,7 +334,7 @@ export class MediaControlsComponent extends AbstractComponent(LitElement) {
       this.requestUpdate();
     };
 
-    const changeNumberHandler = (event: CustomEvent<{ item: SlMenuItem }>) => {
+    const changeNumberHandler = (event: Event) => {
       if (!this.spectrogramElement) {
         throw new Error("No spectrogram element found");
       }
@@ -375,26 +375,32 @@ export class MediaControlsComponent extends AbstractComponent(LitElement) {
         <a slot="trigger">
           <sl-icon name="brightness-high"></sl-icon>
         </a>
-        <label>
-          <input
-            @change="${changeNumberHandler}"
-            name="brightness"
-            type="range"
-            min="-0.5"
-            max="0.5"
-            step="0.1"
-            value="0"
-          />
-        </label>
+
+        <sl-menu>
+          <label>
+            <input
+              @change="${changeNumberHandler}"
+              name="brightness"
+              type="range"
+              min="-0.5"
+              max="0.5"
+              step="0.1"
+              value="0"
+            />
+          </label>
+        </sl-menu>
       </sl-dropdown>
 
       <sl-dropdown title="Contrast" hoist>
         <a slot="trigger">
           <sl-icon name="circle-half"></sl-icon>
         </a>
-        <label>
-          <input @change="${changeNumberHandler}" name="contrast" type="range" min="0" max="2" step="0.1" value="1" />
-        </label>
+
+        <sl-menu>
+          <label>
+            <input @change="${changeNumberHandler}" name="contrast" type="range" min="0" max="2" step="0.1" value="1" />
+          </label>
+        </sl-menu>
       </sl-dropdown>
 
       ${this.additionalSettingsTemplate()}

--- a/src/components/verification-grid-settings/css/style.css
+++ b/src/components/verification-grid-settings/css/style.css
@@ -1,3 +1,15 @@
 :host {
   display: inline-flex;
 }
+
+.settings-container {
+  display: flex;
+}
+
+/* TODO: find out why I have to do this to get all the icons the same size */
+sl-dropdown,
+sl-tooltip {
+  display: flex;
+  width: 100%;
+  height: 100%;
+}

--- a/src/components/verification-grid-settings/verification-grid-settings.spec.ts
+++ b/src/components/verification-grid-settings/verification-grid-settings.spec.ts
@@ -11,28 +11,92 @@ test.describe("Verification Grid Settings Component", () => {
     expect(initialFullscreenState).toBe(false);
   });
 
-  test("should fullscreen the verification grid when the fullscreen button is pressed", async ({ fixture }) => {
-    await fixture.clickFullscreenButton();
+  test.describe("Fullscreen mode", () => {
+    test("should fullscreen the verification grid when the fullscreen button is pressed", async ({ fixture }) => {
+      await fixture.clickFullscreenButton();
 
-    const isFullscreen = await fixture.isFullscreen();
-    expect(isFullscreen).toBe(true);
+      const isFullscreen = await fixture.isFullscreen();
+      expect(isFullscreen).toBe(true);
+    });
+
+    test("should exit fullscreen when the button is pressed when in fullscreen mode", async ({ fixture }) => {
+      await fixture.clickFullscreenButton();
+      await fixture.clickFullscreenButton();
+
+      const isFullscreen = await fixture.isFullscreen();
+      expect(isFullscreen).toBe(false);
+    });
+
+    test("should be able to return to fullscreen after exiting fullscreen using the button", async ({ fixture }) => {
+      await fixture.clickFullscreenButton();
+      await fixture.clickFullscreenButton();
+
+      await fixture.clickFullscreenButton();
+
+      const isFullscreen = await fixture.isFullscreen();
+      expect(isFullscreen).toBe(true);
+    });
   });
 
-  test("should exit fullscreen when the button is pressed when in fullscreen mode", async ({ fixture }) => {
-    await fixture.clickFullscreenButton();
-    await fixture.clickFullscreenButton();
+  test.describe("Changing grid size", () => {
+    // we test that the settings component can change the grid size to one
+    // because it is the smallest value that can be set through the settings
+    // component
+    test("should be able to change the grid size to one", async ({ fixture }) => {
+      const testGridSize = 1;
+      await fixture.changeSettingsGridSize(testGridSize);
 
-    const isFullscreen = await fixture.isFullscreen();
-    expect(isFullscreen).toBe(false);
-  });
+      const realizedGridSize = await fixture.verificationGridSize();
+      expect(realizedGridSize).toBe(testGridSize);
+    });
 
-  test("should be able to return to fullscreen after exiting fullscreen using the button", async ({ fixture }) => {
-    await fixture.clickFullscreenButton();
-    await fixture.clickFullscreenButton();
+    // we test that the settings component can change the grid size to twelve
+    // because it is the largest value that can be set through the settings
+    // component
+    test("should be able to change the grid size to twelve", async ({ fixture }) => {
+      const testGridSize = 12;
+      await fixture.changeSettingsGridSize(testGridSize);
 
-    await fixture.clickFullscreenButton();
+      const realizedGridSize = await fixture.verificationGridSize();
+      expect(realizedGridSize).toBe(testGridSize);
+    });
 
-    const isFullscreen = await fixture.isFullscreen();
-    expect(isFullscreen).toBe(true);
+    // this test asserts that if the verification grids size is updated through
+    // the settings component that the correct grid size is shown in the input
+    test("should have the correct input value after changing the grid size through the input", async ({ fixture }) => {
+      const testValue = 8;
+      await fixture.changeSettingsGridSize(testValue);
+
+      const realizedInputValue = await fixture.gridSizeInputValue();
+      expect(realizedInputValue).toBe(testValue.toString());
+    });
+
+    test("should have the correct label after changing the grid size through the input", async ({ fixture }) => {
+      const expectedLabel = "8";
+      await fixture.changeSettingsGridSize(8);
+      await expect(fixture.gridSizeLabel()).toHaveText(expectedLabel);
+    });
+
+    // this tests asserts that if the verification grids size is updated
+    // not through the settings component (e.g. through an attribute change)
+    // that the correct grid size is shown in the input
+    test("should have the correct input value after changing the grid size through grid", async ({ fixture }) => {
+      const testValue = "4";
+      await fixture.changeVerificationGridSize(testValue);
+
+      const realizedInputValue = await fixture.gridSizeInputValue();
+      expect(realizedInputValue).toBe(testValue);
+    });
+
+    test("should have the correct label after changing the grid size through grid", async ({ fixture }) => {
+      const expectedLabel = "8";
+      await fixture.changeSettingsGridSize(8);
+      await expect(fixture.gridSizeLabel()).toHaveText(expectedLabel);
+    });
+
+    // TODO: these tests are currently disabled because we have not implemented
+    // the functionality ot automatically scale down the verification grid if
+    // it does not fit on the screen
+    test.skip("should not be able to change the grid size to a count that would not fit on the screen", () => {});
   });
 });

--- a/src/helpers/advancedTypes.ts
+++ b/src/helpers/advancedTypes.ts
@@ -19,3 +19,13 @@ export type EnumKeyValue<T extends Enum, key extends keyof T> = Readonly<T[key]>
 // didn't export the type
 /** An attribute converter type alias defined by Lit */
 export type AttributeConverter = PropertyDeclaration["converter"];
+
+// TODO: this type should use a type guard to check that the "target" property
+// on the original event satisfies the generic T
+/**
+ * A type that represents a change event emitted by a HTML element
+ * @template T The type of the events target element
+ */
+export type ChangeEvent<T extends HTMLElement> = Event & {
+  target: T;
+};

--- a/src/tests/helpers.ts
+++ b/src/tests/helpers.ts
@@ -33,6 +33,13 @@ export async function getBrowserStyles<T extends HTMLElement>(component: Locator
   });
 }
 
+export async function emitBrowserEvent<T extends HTMLElement>(locator: Locator, eventName: string) {
+  return locator.evaluate((element: T, name: string) => {
+    const event = new Event(name, { bubbles: true });
+    element.dispatchEvent(event);
+  }, eventName);
+}
+
 export async function catchEvent(locator: Page, name: string) {
   return locator.evaluate((name: string) => {
     return new Promise((resolve) => {

--- a/src/tests/verification-grid/verification-grid.e2e.fixture.ts
+++ b/src/tests/verification-grid/verification-grid.e2e.fixture.ts
@@ -17,7 +17,7 @@ import {
   VerificationGridTileComponent,
 } from "../../components";
 import { SubjectWrapper } from "../../models/subject";
-import { DecisionId } from "../../models/decisions/decision";
+import { Decision, DecisionId } from "../../models/decisions/decision";
 
 class TestPage {
   public constructor(public readonly page: Page) {}
@@ -139,6 +139,11 @@ class TestPage {
     return values;
   }
 
+  public async appliedDecisions(): Promise<Decision[]> {
+    const tileModels = await this.verificationGridTileModels();
+    return tileModels.flatMap((model) => model.decisionModels);
+  }
+
   public async tileHighlightColors(): Promise<number[]> {
     const values: number[] = [];
     const tiles = await this.gridTileComponents();
@@ -188,6 +193,15 @@ class TestPage {
     }
 
     return highlightedButtons.map((_, i) => i);
+  }
+  public async verificationGridTileModels(): Promise<SubjectWrapper[]> {
+    const gridTiles = await this.gridTileComponents();
+
+    const gridTileModels = gridTiles.map(async (tile) => {
+      return (await getBrowserValue<VerificationGridTileComponent>(tile, "model")) as SubjectWrapper;
+    });
+
+    return await Promise.all(gridTileModels);
   }
 
   public async areMediaControlsPlaying(index: number): Promise<boolean> {


### PR DESCRIPTION
# Add UI to change verification grid size

This pull request exposes a user interface to change the verification grid size after creation

## Changes

### Features

- Adds a button to change the verification grid size

### Bug Fixes

- Fix a bug where increasing the grid size after initalization would not cause the new spectrograms to generate
- Fix a bug where if the same URL was used for two grid tiles in the same position, the subject model would not update

### Code Quality

- Corrects typing of media controls `changeNumberHandlerEvent` callback to a `HTMLInputElement` `Event` instead of a `SLMenuItem` event

### Remaining Bugs / Unresolved Problems

Because this PR exposes the verification grid size to the user #146, and #147 become much more prevelant because the user can input grid sizes that (obviously) won't fit on their screen and start scrolling.

## Visual Changes

![image](https://github.com/user-attachments/assets/71b1a34f-cce1-4c8b-aad8-7b1c5c579d5c)

_A new scrollbar + label that can be used to change the verification grid size_

![image](https://github.com/user-attachments/assets/bfc14792-b36b-458c-9f2f-c0f38cb5ff35)

_Media controls now has a wrapper around the range inputs_

## Related Issues

Fixes: #137 

## Additional Notes

N.A.

## Final Checklist

- [ ] All commits messages are semver compliant
- [x] Added relevant unit tests for new functionality
- [x] Updated existing unit tests to reflect changes
- [x] Code style is consistent with the project guidelines
- [ ] Documentation is updated to reflect the changes (if applicable)
- [x] Link issues related to the PR
- [x] Assign labels if you have permission
- [x] Assign reviewers if you have permission
- [x] Ensure that CI is passing
- [x] Ensure that `pnpm lint` runs without any errors
- [x] Ensure that `pnpm test` runs without any errors
