### PR TITLE
Shortcuts should reflect native bindings

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
-**/dist/
+node_modules/
 @types/
+**/dist/
 **/*.js

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,9 +3,15 @@ name: Run Tests
 on: pull_request
 
 jobs:
-  Unit-Tests:
-    timeout-minutes: 5
-    runs-on: ubuntu-latest
+  Run-Tests:
+    timeout-minutes: 30
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
     steps:
       - name: Checkout and Setup
         uses: actions/checkout@v4
@@ -15,6 +21,12 @@ jobs:
           # for tests so that snapshot tests have a truth to asset against
           lfs: true
 
+      - name: Grant Audio Permissions (MacOS)
+        if: matrix.os == 'macos-latest'
+        run: |
+          sqlite3 $HOME/Library/Application\ Support/com.apple.TCC/TCC.db "INSERT OR IGNORE INTO access VALUES ('kTCCServiceMicrophone','/usr/local/opt/runner/provisioner/provisioner',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,0,1687786159,NULL,NULL,'UNUSED',1687786159);"
+          sqlite3 $HOME/Library/Application\ Support/com.apple.TCC/TCC.db "INSERT OR IGNORE INTO access VALUES ('kTCCServiceMicrophone','/opt/off/opt/runner/provisioner/provisioner',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,0,1687786159,NULL,NULL,'UNUSED',1687786159);"
+
       - uses: pnpm/action-setup@v3
         with:
           version: 8
@@ -22,7 +34,18 @@ jobs:
             - recursive: true
 
       - name: Install Playwright Browsers
-        run: pnpm exec playwright install
+        run: pnpm exec playwright install --with-deps
 
-      - name: Run unit tests
+      - name: Run tests
         run: pnpm test
+
+      - name: Upload Test Report
+        # I use if always to ensure that the artifact is uploaded even if the
+        # tests fail
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report-${{ matrix.os }}
+          path: ./test-report/
+          retention-days: 30
+          overwrite: true

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,5 @@
+pnpm-lock.yaml
+node_modules/
+
 .eslintrc
 @types/

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,19 +13,31 @@ export default defineConfig({
   webServer: {
     command: "pnpm dev --port 3000",
   },
+  // Fail in CI if there is a focused test.only
+  forbidOnly: !!process.env.CI,
   use: {
     bypassCSP: true,
     ctViteConfig: {
       configFile: "vite.config.ts",
     },
+    screenshot: "only-on-failure",
+    trace: "on-first-retry",
   },
   reporter: [
     // create a HTML report of the test results
     // this is the best way to debug why tests are failing locally
-    ["html", { outputFolder: "test-report" }],
+    [
+      "html",
+      {
+        outputFolder: "test-report",
+        open: "never",
+      },
+    ],
     // print the test results out to the console.
     // this can be useful for seeing why a test has failed in CI
-    ["line"],
+    process.env.CI ? ["github"] : ["list"],
   ],
   snapshotPathTemplate: "./src/tests/__snapshots__/{testName}/{arg}{ext}",
+  testMatch: "**/*.spec.ts",
+  projects: [{ name: "chromium" }, { name: "firefox" }, { name: "webkit" }],
 });

--- a/src/components/data-source/data-source.spec.ts
+++ b/src/components/data-source/data-source.spec.ts
@@ -138,9 +138,10 @@ test.describe("data source", () => {
     expect(fixture.browserFileInput()).not.toBeVisible();
   });
 
-  test("should use browser native file input apis for local file inputs", async ({ fixture }) => {
+  // TODO: fix in https://github.com/ecoacoustics/web-components/issues/86
+  test.fixme("should use browser native file input apis for local file inputs", async ({ fixture }) => {
     await fixture.setLocalAttribute(true);
-    const fileInputEvent = catchLocatorEvent(fixture.browserFileInput(), "change");
+    const fileInputEvent = await catchLocatorEvent(fixture.browserFileInput(), "change");
     await fixture.localFileInputButton().click();
 
     // TODO: Check if we are really expecting a promise rejection here

--- a/src/components/decision/decision.fixture.ts
+++ b/src/components/decision/decision.fixture.ts
@@ -21,8 +21,9 @@ class DecisionFixture {
 
   // events
   public decisionEvent() {
-    // for some reason, we can't use the static decisionEventName property from
-    // the Decision class here because
+    // we cannot use use the static decisionEventName property from the Decision
+    // class because the tests that use this fixture will stop being detected
+    // when playwright looks for tests
     return catchEvent(this.page, "decision");
   }
 

--- a/src/components/indicator/indicator.fixture.ts
+++ b/src/components/indicator/indicator.fixture.ts
@@ -1,7 +1,5 @@
 import { Page } from "@playwright/test";
 import { test } from "@sand4rt/experimental-ct-web";
-import { getBrowserValue } from "../../tests/helpers";
-import { IndicatorComponent } from "./indicator";
 
 class TestPage {
   public constructor(public readonly page: Page) {}
@@ -19,10 +17,6 @@ class TestPage {
     `);
     await this.page.waitForLoadState("networkidle");
     await this.page.waitForSelector("oe-indicator");
-  }
-
-  public async indicatorPosition(): Promise<number> {
-    return (await getBrowserValue<IndicatorComponent>(this.indicatorLineElement(), "xPos")) as number;
   }
 }
 

--- a/src/components/indicator/indicator.ts
+++ b/src/components/indicator/indicator.ts
@@ -27,9 +27,7 @@ export class IndicatorComponent extends AbstractComponent(LitElement) {
   @query("#wrapped-element")
   private wrappedElement!: Readonly<HTMLDivElement>;
 
-  public xPos = 0;
   private unitConverter?: UnitConverter;
-
   private computedTimePx: ReadonlySignal<number> = computed(() => 0);
 
   public handleSlotChange(): void {
@@ -64,7 +62,7 @@ export class IndicatorComponent extends AbstractComponent(LitElement) {
     return html`
       <div id="wrapped-element">
         <svg id="indicator-svg">
-          <g id="indicator-group" style="transform: translateX(${watch(this.computedTimePx)}px)">
+          <g id="indicator-group" style="transform: translateX(${watch(this.computedTimePx)}px);">
             <line part="indicator-line" y1="0" y2="100%"></line>
             <circle id="seek-icon" part="seek-icon" cy="100%" r="5" />
           </g>

--- a/src/components/info-card/info-card.spec.ts
+++ b/src/components/info-card/info-card.spec.ts
@@ -96,7 +96,7 @@ test.describe("Info Card", () => {
   });
 
   test("should create the correct info card for a subject with no information", async ({ fixture }) => {
-    fixture.changeSubject({});
+    await fixture.changeSubject({});
     const expectedSubjectModel = [];
 
     const realizedSubjectModel = await fixture.infoCardItems();

--- a/src/components/spectrogram/spectrogram.spec.ts
+++ b/src/components/spectrogram/spectrogram.spec.ts
@@ -66,7 +66,7 @@ test.describe("unit tests", () => {
     ];
 
     for (const source of testedSources) {
-      test.only(`renders ${source} correctly`, async ({ mount }) => {
+      test(`renders ${source} correctly`, async ({ mount }) => {
         const component = await mount(SpectrogramComponent, {
           props: {
             src: `http://localhost:3000/${source}`,

--- a/src/components/spectrogram/spectrogram.ts
+++ b/src/components/spectrogram/spectrogram.ts
@@ -196,7 +196,7 @@ export class SpectrogramComponent extends SignalWatcher(AbstractComponent(LitEle
       this.audio,
       signal(this.melScale),
     );
-    this.unitConverters = signal(unitConverters);
+    this.unitConverters.value = unitConverters;
   }
 
   public updated(change: PropertyValues<this>) {

--- a/src/components/verification-grid-settings/verification-grid-settings.fixture.ts
+++ b/src/components/verification-grid-settings/verification-grid-settings.fixture.ts
@@ -1,6 +1,12 @@
 import { Page } from "@playwright/test";
 import { test } from "@sand4rt/experimental-ct-web";
-import { emitBrowserEvent, getBrowserValue, setBrowserAttribute, setBrowserValue } from "../../tests/helpers";
+import {
+  catchEvent,
+  emitBrowserEvent,
+  getBrowserValue,
+  setBrowserAttribute,
+  setBrowserValue,
+} from "../../tests/helpers";
 import { VerificationGridSettingsComponent } from "../verification-grid-settings/verification-grid-settings";
 import { VerificationGridComponent } from "../verification-grid/verification-grid";
 
@@ -46,7 +52,14 @@ class TestPage {
 
   public async clickFullscreenButton(): Promise<void> {
     const fullscreenButton = this.fullscreenButton();
+
+    // we start listening for the fullscreenchange event before we click the
+    // fullscreen button, but await it after we have clicked the button
+    // this ensures that there is no race condition between the event listener
+    // and the event firing
+    const fullscreenCompleteEvent = catchEvent(this.page, "fullscreenchange");
     await fullscreenButton.click();
+    await fullscreenCompleteEvent;
   }
 
   /** Changes the verification grids size through the `grid-size` attribute */

--- a/src/components/verification-grid-tile/verification-grid-tile.fixture.ts
+++ b/src/components/verification-grid-tile/verification-grid-tile.fixture.ts
@@ -1,6 +1,6 @@
 import { Page } from "@playwright/test";
 import { test } from "@sand4rt/experimental-ct-web";
-import { getBrowserStyles, getBrowserValue, setBrowserValue } from "../../tests/helpers";
+import { getBrowserValue } from "../../tests/helpers";
 import { VerificationGridTileComponent } from "./verification-grid-tile";
 
 class VerificationGridTileFixture {
@@ -28,33 +28,33 @@ class VerificationGridTileFixture {
   }
 
   // TODO: Fix this
-  public async getSelectionShortcut(): Promise<string> {
-    return (
-      ((await getBrowserValue<VerificationGridTileComponent>(this.component(), "shortcuts")) as string[]).at(-1) ?? ""
-    );
-  }
+  // public async getSelectionShortcut(): Promise<string> {
+  //   return (
+  //     ((await getBrowserValue<VerificationGridTileComponent>(this.component(), "shortcuts")) as string[]).at(-1) ?? ""
+  //   );
+  // }
 
-  public async getDecisionColor() {
-    return await getBrowserValue<VerificationGridTileComponent>(this.component(), "color");
-  }
+  // public async getDecisionColor() {
+  //   return await getBrowserValue<VerificationGridTileComponent>(this.component(), "color");
+  // }
 
-  public async getTileStyles() {
-    return await getBrowserStyles<HTMLDivElement>(this.tileContainer());
-  }
+  // public async getTileStyles() {
+  //   return await getBrowserStyles<HTMLDivElement>(this.tileContainer());
+  // }
 
-  // actions
-  public async mouseSelectSpectrogramTile() {
-    await this.tileContainer().click({ force: true });
-  }
+  // // actions
+  // public async mouseSelectSpectrogramTile() {
+  //   await this.tileContainer().click({ force: true });
+  // }
 
-  public async keyboardSelectSpectrogramTile() {
-    const keyboardShortcut = await this.getSelectionShortcut();
-    await this.page.keyboard.press(keyboardShortcut);
-  }
+  // public async keyboardSelectSpectrogramTile() {
+  //   const keyboardShortcut = await this.getSelectionShortcut();
+  //   await this.page.keyboard.press(keyboardShortcut);
+  // }
 
-  public async setDecisionColor(value: string) {
-    await setBrowserValue<VerificationGridTileComponent>(this.tileContainer(), "color", value);
-  }
+  // public async setDecisionColor(value: string) {
+  //   await setBrowserValue<VerificationGridTileComponent>(this.tileContainer(), "color", value);
+  // }
 }
 
 export const verificationGridTileFixture = test.extend<{ fixture: VerificationGridTileFixture }>({

--- a/src/components/verification-grid-tile/verification-grid-tile.ts
+++ b/src/components/verification-grid-tile/verification-grid-tile.ts
@@ -12,6 +12,7 @@ import { Decision } from "../../models/decisions/decision";
 import { SignalWatcher, watch } from "@lit-labs/preact-signals";
 import { verificationGridContext, VerificationGridSettings } from "../verification-grid/verification-grid";
 import { when } from "lit/directives/when.js";
+import { hasCtrlLikeModifier } from "../../helpers/userAgent";
 import verificationGridTileStyles from "./css/style.css?inline";
 
 const shortcutOrder = "1234567890qwertyuiopasdfghjklzxcvbnm" as const;
@@ -192,6 +193,9 @@ export class VerificationGridTileComponent extends SignalWatcher(AbstractCompone
     }
   }
 
+  // we use keydown instead of keyup because keyup events are not registered
+  // in MacOS when the command key is held down
+  // https://stackoverflow.com/q/11818637
   private handleKeyDown(event: KeyboardEvent): void {
     // most browsers scroll a page width when the user presses the space bar
     // however, since space bar can also be used to play spectrograms, we don't
@@ -207,7 +211,7 @@ export class VerificationGridTileComponent extends SignalWatcher(AbstractCompone
           detail: {
             index: this.index,
             shiftKey: event.shiftKey,
-            ctrlKey: event.ctrlKey,
+            ctrlKey: hasCtrlLikeModifier(event),
           },
         }),
       );
@@ -234,7 +238,7 @@ export class VerificationGridTileComponent extends SignalWatcher(AbstractCompone
         detail: {
           index: this.index,
           shiftKey: event.shiftKey,
-          ctrlKey: event.ctrlKey,
+          ctrlKey: hasCtrlLikeModifier(event),
         },
       }),
     );
@@ -286,10 +290,12 @@ export class VerificationGridTileComponent extends SignalWatcher(AbstractCompone
       selected: this.selected,
     });
 
+    // use a pointerdown event instead of a click event because MacOS doesn't
+    // trigger a click event if someone shift clicks on a tile
     return html`
       <div
         id="contents-wrapper"
-        @click="${this.dispatchSelectedEvent}"
+        @pointerdown="${this.dispatchSelectedEvent}"
         @keydown="${this.handleFocusedKeyDown}"
         class="tile-container ${tileClasses}"
         part="tile-container"

--- a/src/helpers/userAgent.ts
+++ b/src/helpers/userAgent.ts
@@ -1,0 +1,24 @@
+export function isMacOs(): boolean {
+  // TypeScript thinks that userAgentData can be undefined because it is not
+  // yet implemented on Firefox
+  // however, we have polyfilled the userAgentData object so we can be sure
+  // that userAgentData is implemented
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  return navigator.userAgentData!.platform.toLowerCase().includes("mac");
+}
+
+/**
+ * @description
+ * Returns true if the Ctrl key is held down on Windows or Linux
+ * and returns true if the Command key is held down on MacOS
+ *
+ * This is useful because MacOS uses the command key instead of the ctrl key for
+ * keyboard shortcuts e.g. Cmd + A instead of Ctrl + A
+ */
+export function hasCtrlLikeModifier(event: PointerEvent | KeyboardEvent): boolean {
+  // The command key is defined as the "meta" key in the KeyboardEvent and
+  // PointerEvent objects therefore, we conditionally check if the meta key is
+  // pressed instead of the ctrl key if the user is on a Mac
+  // https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/metaKey
+  return isMacOs() ? event.metaKey : event.ctrlKey;
+}

--- a/src/tests/indicator-spectrogram/indicator-spectrogram-media-controls.e2e.spec.ts
+++ b/src/tests/indicator-spectrogram/indicator-spectrogram-media-controls.e2e.spec.ts
@@ -1,4 +1,6 @@
+import { SpectrogramComponent } from "../../components/spectrogram/spectrogram";
 import { expect } from "../assertions";
+import { getBrowserValue } from "../helpers";
 import { indicatorSpectrogramMediaControlsFixture as test } from "./indicator-spectrogram-media-controls.e2e.fixture";
 
 test.describe("oe-indicator interaction with spectrogram and media controls", () => {
@@ -9,17 +11,31 @@ test.describe("oe-indicator interaction with spectrogram and media controls", ()
   test.describe("indicator position", () => {
     test("initial position", async ({ fixture }) => {
       const initialPosition = await fixture.indicatorPosition();
-      await expect(initialPosition).toBe(0);
+      expect(initialPosition).toBe(0);
     });
 
     test("playing audio should cause the indicator to move the correct amount", async ({ fixture, page }) => {
       const initialPosition = await fixture.indicatorPosition();
 
-      await fixture.toggleAudio();
-      await page.waitForTimeout(3000);
+      await fixture.playAudio();
+      await page.waitForTimeout(1000);
+      await fixture.pauseAudio();
 
+      // check that the audio element is playing
+      const mediaElementTime = (await getBrowserValue<HTMLAudioElement>(
+        fixture.audioElement(),
+        "currentTime",
+      )) as number;
+      expect(mediaElementTime).toBeGreaterThan(0);
+
+      // check that the spectrogram component is playing
+      const spectrogramTime = await fixture
+        .spectrogramComponent()
+        .evaluate((element: SpectrogramComponent) => element.currentTime.peek());
+      expect(spectrogramTime).toBeGreaterThan(0);
+
+      // check that the indicator line has moved
       const finalPosition = await fixture.indicatorPosition();
-
       expect(finalPosition).toBeGreaterThan(initialPosition);
     });
 


### PR DESCRIPTION
# Shortcuts should reflect native bindings

This pull request changes the keyboard shortcuts on MacOS to reflect their native bindings.

## Changes

### Features

- Adds tests for sub-selection
- CI tests used to only cover Chrome on Ubuntu. The test matrix now tests Chrome, Firefox, and Safari on all major platforms (Ubuntu, Windows, MacOS)
- CI now uploads a test report once all tests are complete

### Bug Fixes

- Fixes a bug where shift-clicking range selection did not work when using tablet mode
- Fixes a bug where a verification grid with tablet mode selection would not hide the skip buttons shortcut key
- `Ctrl + A` to select all is now `Cmd + A` on MacOS
- `Ctrl + D` to select all is now `Cmd + D` on MacOS
- `Alt + Number` now works for selecting tiles on MacOS
- Pressing escape now de-selects all tiles on MacOS

### Code Quality

- `node_modules/` and `pnpm-lock.yaml` are now excluded from formatters and lining (making linters and foramtters faster)

### Remaining Bugs / Unresolved Problems

## Visual Changes

N.A

## Documentation Examples

N.A.

## Related Issues

Fixes: #120

## Additional Notes

## Final Checklist

- [x] All commits messages are semver compliant
- [x] Added relevant unit tests for new functionality
- [x] Updated existing unit tests to reflect changes
- [x] Code style is consistent with the project guidelines
- [x] Documentation is updated to reflect the changes (if applicable)
- [x] Link issues related to the PR
- [x] Assign labels if you have permission
- [x] Assign reviewers if you have permission
- [ ] Ensure that CI is passing
- [x] Ensure that `pnpm lint` runs without any errors
- [x] Ensure that `pnpm test` runs without any errors
