### PR TITLE
Show completed actions in segmented meter

### DIFF
--- a/docs-src/examples/index.md
+++ b/docs-src/examples/index.md
@@ -17,6 +17,8 @@ title: Open Ecoacoustics | Examples
 
 [Verification Grid (Multiple Classes - Additional Tags)](./verification/multi-additional/index.html)
 
+[Classification Grid](./verification/classification/index.html)
+
 [How to Create a Verification grid](./create-verification-grid/index.html)
 
 [Presets](./presets/index.html)

--- a/docs-src/examples/verification/classification.md
+++ b/docs-src/examples/verification/classification.md
@@ -1,0 +1,18 @@
+---
+layout: layouts/verification.11ty.js
+title: Open Ecoacoustics | Examples | Verification | Multiple Class
+---
+
+<h2 class="grid-title">Verification Interface (Multiple Classes)</h2>
+
+<oe-verification-grid id="verification-grid" grid-size="5">
+  <oe-classification tag="koala" verified="true" shortcut="H">Koala</oe-classification>
+  <oe-classification tag="koala" verified="false" shortcut="J">Not Koala</oe-classification>
+  <oe-classification tag="car" shortcut="K">Car</oe-classification>
+  <oe-classification tag="car" verified="false" shortcut="L">Not Car</oe-classification>
+  <oe-classification tag="crickets" shortcut="Q">Crickets</oe-classification>
+  <oe-classification tag="crickets" verified="false" shortcut="W">Not Crickets</oe-classification>
+
+  <oe-data-source slot="data-source" for="verification-grid" src="/public/grid-items.json" local>
+  </oe-data-source>
+</oe-verification-grid>

--- a/public/test-items.json
+++ b/public/test-items.json
@@ -8,7 +8,8 @@
     "SiteId": 255,
     "Offset": 30,
     "AudioLink": "http://localhost:3000/example.flac",
-    "Distance": "4.542739391326904"
+    "Distance": "4.542739391326904",
+    "Tag": "koala"
   },
   {
     "Filename": "20210527T140000+1000_Mt-Barney-Wet-B_515726.flac",
@@ -19,7 +20,8 @@
     "SiteId": 4,
     "Offset": 45,
     "AudioLink": "http://localhost:3000/example.flac",
-    "Distance": "4.6433424949646"
+    "Distance": "4.6433424949646",
+    "Tag": "koala"
   },
   {
     "Filename": "20191216T070000+1100_Little-Llangothlin-Reserve-Warra-National-Park-Dry-B_16714.flac",
@@ -30,7 +32,8 @@
     "SiteId": 44,
     "Offset": 5,
     "AudioLink": "http://localhost:3000/example.flac",
-    "Distance": "4.846035957336426"
+    "Distance": "4.846035957336426",
+    "Tag": "koala"
   },
   {
     "Filename": "20191022T140000+1000_SEQP-Samford-Dry-B_251486.flac",
@@ -41,7 +44,8 @@
     "SiteId": 255,
     "Offset": 15,
     "AudioLink": "http://localhost:3000/example.flac",
-    "Distance": "4.958763122558594"
+    "Distance": "4.958763122558594",
+    "Tag": "koala"
   },
   {
     "Filename": "20200413T120000+0800_Boyagin-Nature-Reserve-Wet-A_177657.flac",
@@ -52,7 +56,8 @@
     "SiteId": 219,
     "Offset": 40,
     "AudioLink": "http://localhost:3000/example.flac",
-    "Distance": "5.02945613861084"
+    "Distance": "5.02945613861084",
+    "Tag": "koala"
   },
   {
     "Filename": "20200915T120000+1000_SEQP-Samford-Dry-B_266173.flac",
@@ -63,7 +68,8 @@
     "SiteId": 255,
     "Offset": 45,
     "AudioLink": "http://localhost:3000/example.flac",
-    "Distance": "5.045819282531738"
+    "Distance": "5.045819282531738",
+    "Tag": "koala"
   },
   {
     "Filename": "20191022T140000+1000_SEQP-Samford-Dry-B_251486.flac",
@@ -74,7 +80,8 @@
     "SiteId": 255,
     "Offset": 15,
     "AudioLink": "http://localhost:3000/example.flac",
-    "Distance": "5.081274509429932"
+    "Distance": "5.081274509429932",
+    "Tag": "koala"
   },
   {
     "Filename": "20211017T090000+1100_Duval-Wet-A_969189.flac",
@@ -85,7 +92,8 @@
     "SiteId": 90,
     "Offset": 0,
     "AudioLink": "http://localhost:3000/example.flac",
-    "Distance": "5.128411293029785"
+    "Distance": "5.128411293029785",
+    "Tag": "koala"
   },
   {
     "Filename": "20211017T090000+1100_Duval-Wet-A_969189.flac",
@@ -96,7 +104,8 @@
     "SiteId": 90,
     "Offset": 0,
     "AudioLink": "http://localhost:3000/example.flac",
-    "Distance": "5.140925407409668"
+    "Distance": "5.140925407409668",
+    "Tag": "koala"
   },
   {
     "Filename": "20211215T000000Z_Duval-Dry-B_1060970.flac",
@@ -107,7 +116,8 @@
     "SiteId": 91,
     "Offset": 10,
     "AudioLink": "http://localhost:3000/example.flac",
-    "Distance": "5.146507263183594"
+    "Distance": "5.146507263183594",
+    "Tag": "koala"
   },
   {
     "Filename": "20210306T110000+1100_Little-Llangothlin-Reserve-Warra-National-Park-Dry-A_718570.flac",
@@ -118,7 +128,8 @@
     "SiteId": 41,
     "Offset": 30,
     "AudioLink": "http://localhost:3000/example.flac",
-    "Distance": "5.148530006408691"
+    "Distance": "5.148530006408691",
+    "Tag": "koala"
   },
   {
     "Filename": "20210102T150000+1100_Duval-Dry-A_1062175.flac",
@@ -129,7 +140,8 @@
     "SiteId": 89,
     "Offset": 40,
     "AudioLink": "http://localhost:3000/example.flac",
-    "Distance": "5.149863243103027"
+    "Distance": "5.149863243103027",
+    "Tag": "koala"
   },
   {
     "Filename": "20211021T140000+1000_Doonan-Creek-Environmental-Reserve-Dry-B_780158.flac",
@@ -140,7 +152,8 @@
     "SiteId": 87,
     "Offset": 35,
     "AudioLink": "http://localhost:3000/example.flac",
-    "Distance": "5.221043586730957"
+    "Distance": "5.221043586730957",
+    "Tag": "koala"
   },
   {
     "Filename": "20211120T160000+1000_SEQP-Samford-Dry-B_649103.flac",
@@ -151,7 +164,8 @@
     "SiteId": 255,
     "Offset": 35,
     "AudioLink": "http://localhost:3000/example.flac",
-    "Distance": "5.2308220863342285"
+    "Distance": "5.2308220863342285",
+    "Tag": "koala"
   },
   {
     "Filename": "20210319T150000+1100_Duval-Wet-A_967795.flac",
@@ -162,7 +176,8 @@
     "SiteId": 90,
     "Offset": 30,
     "AudioLink": "http://localhost:3000/example.flac",
-    "Distance": "5.250988006591797"
+    "Distance": "5.250988006591797",
+    "Tag": "koala"
   },
   {
     "Filename": "20200808T180000+1000_Eungella-Dry-B_502031.flac",
@@ -173,7 +188,8 @@
     "SiteId": 112,
     "Offset": 40,
     "AudioLink": "http://localhost:3000/example.flac",
-    "Distance": "5.251277923583984"
+    "Distance": "5.251277923583984",
+    "Tag": "koala"
   },
   {
     "Filename": "20211205T070000+1100_Scottsdale-Dry-B_927139.flac",
@@ -184,7 +200,8 @@
     "SiteId": 55,
     "Offset": 45,
     "AudioLink": "http://localhost:3000/example.flac",
-    "Distance": "5.253893852233887"
+    "Distance": "5.253893852233887",
+    "Tag": "koala"
   },
   {
     "Filename": "20200409T160000+0800_Boyagin-Nature-Reserve-Dry-A_172745.flac",
@@ -195,7 +212,8 @@
     "SiteId": 217,
     "Offset": 55,
     "AudioLink": "http://localhost:3000/example.flac",
-    "Distance": "5.2864179611206055"
+    "Distance": "5.2864179611206055",
+    "Tag": "koala"
   },
   {
     "Filename": "20191111T160000+1000_SEQP-Samford-Dry-A_249561.flac",
@@ -206,7 +224,8 @@
     "SiteId": 253,
     "Offset": 10,
     "AudioLink": "http://localhost:3000/example.flac",
-    "Distance": "5.36638879776001"
+    "Distance": "5.36638879776001",
+    "Tag": "koala"
   },
   {
     "Filename": "20200922T080000+1000_SEQP-Samford-Dry-A_261821.flac",
@@ -217,7 +236,8 @@
     "SiteId": 253,
     "Offset": 5,
     "AudioLink": "http://localhost:3000/example.flac",
-    "Distance": "5.376502990722656"
+    "Distance": "5.376502990722656",
+    "Tag": "koala"
   },
   {
     "Filename": "20201014T170000+1100_Little-Llangothlin-Reserve-Warra-National-Park-Dry-B_719551.flac",
@@ -228,7 +248,8 @@
     "SiteId": 44,
     "Offset": 10,
     "AudioLink": "http://localhost:3000/example.flac",
-    "Distance": "5.378347396850586"
+    "Distance": "5.378347396850586",
+    "Tag": "koala"
   },
   {
     "Filename": "20210115T090000+1100_Little-Llangothlin-Reserve-Warra-National-Park-Dry-B_723161.flac",
@@ -239,7 +260,8 @@
     "SiteId": 44,
     "Offset": 35,
     "AudioLink": "http://localhost:3000/example.flac",
-    "Distance": "5.393798828125"
+    "Distance": "5.393798828125",
+    "Tag": "koala"
   },
   {
     "Filename": "20210425T080000+1000_Little-Llangothlin-Reserve-Warra-National-Park-Dry-A_718326.flac",
@@ -250,7 +272,8 @@
     "SiteId": 41,
     "Offset": 15,
     "AudioLink": "http://localhost:3000/example.flac",
-    "Distance": "5.3959245681762695"
+    "Distance": "5.3959245681762695",
+    "Tag": "koala"
   },
   {
     "Filename": "20220416T220000Z_Duval-Wet-B_1057937.flac",
@@ -261,7 +284,8 @@
     "SiteId": 92,
     "Offset": 20,
     "AudioLink": "http://localhost:3000/example.flac",
-    "Distance": "5.3980865478515625"
+    "Distance": "5.3980865478515625",
+    "Tag": "koala"
   },
   {
     "Filename": "20210115T090000+1100_Little-Llangothlin-Reserve-Warra-National-Park-Dry-B_723161.flac",
@@ -272,7 +296,8 @@
     "SiteId": 44,
     "Offset": 35,
     "AudioLink": "http://localhost:3000/example.flac",
-    "Distance": "5.399255752563477"
+    "Distance": "5.399255752563477",
+    "Tag": "koala"
   },
   {
     "Filename": "20210316T120000+1000_Mt-Barney-Wet-A_514661.flac",
@@ -283,7 +308,8 @@
     "SiteId": 2,
     "Offset": 55,
     "AudioLink": "http://localhost:3000/example.flac",
-    "Distance": "5.4007062911987305"
+    "Distance": "5.4007062911987305",
+    "Tag": "koala"
   },
   {
     "Filename": "20210129T080000+1000_Mt-Barney-Wet-A_514101.flac",
@@ -294,7 +320,8 @@
     "SiteId": 2,
     "Offset": 0,
     "AudioLink": "http://localhost:3000/example.flac",
-    "Distance": "5.401859283447266"
+    "Distance": "5.401859283447266",
+    "Tag": "koala"
   },
   {
     "Filename": "20200922T040000+1000_Eungella-Wet-B_501256.flac",
@@ -305,7 +332,8 @@
     "SiteId": 111,
     "Offset": 35,
     "AudioLink": "http://localhost:3000/example.flac",
-    "Distance": "5.403575897216797"
+    "Distance": "5.403575897216797",
+    "Tag": "koala"
   },
   {
     "Filename": "20200223T090000+1100_Little-Desert-Nature-Lodge-Dry-B_29587.flac",
@@ -316,7 +344,8 @@
     "SiteId": 296,
     "Offset": 35,
     "AudioLink": "http://localhost:3000/example.flac",
-    "Distance": "5.403904914855957"
+    "Distance": "5.403904914855957",
+    "Tag": "koala"
   },
   {
     "Filename": "20190923T160000+1000_SEQP-Samford-Dry-A_248973.flac",
@@ -327,6 +356,7 @@
     "SiteId": 253,
     "Offset": 45,
     "AudioLink": "http://localhost:3000/example.flac",
-    "Distance": "5.410007476806641"
+    "Distance": "5.410007476806641",
+    "Tag": "koala"
   }
 ]

--- a/src/components/decision/decision.spec.ts
+++ b/src/components/decision/decision.spec.ts
@@ -145,7 +145,7 @@ test.describe("decision", () => {
     test("should emit an event when clicked", async ({ fixture }) => {
       const decisionEvent = fixture.decisionEvent();
       await fixture.decisionButton().click();
-      expect(decisionEvent).resolves.toBeTruthy();
+      await expect(decisionEvent).resolves.toBeTruthy();
     });
 
     // we should only see the keyboard shortcut trigger on keyup
@@ -157,7 +157,7 @@ test.describe("decision", () => {
 
       await fixture.page.keyboard.press(keyboardShortcut);
 
-      expect(decisionEvent).resolves.toBeTruthy();
+      await expect(decisionEvent).resolves.toBeTruthy();
     });
 
     test("should emit the correct event for a skip decision", async ({ fixture }) => {
@@ -166,7 +166,7 @@ test.describe("decision", () => {
       const decisionEvent = fixture.decisionEvent();
       await fixture.decisionButton().click();
 
-      expect(decisionEvent).resolves.toBeTruthy();
+      await expect(decisionEvent).resolves.toBeTruthy();
     });
 
     test("should emit the correct event for a unsure decision", async ({ fixture }) => {
@@ -175,7 +175,7 @@ test.describe("decision", () => {
       const decisionEvent = fixture.decisionEvent();
       await fixture.decisionButton().click();
 
-      expect(decisionEvent).resolves.toBeTruthy();
+      await expect(decisionEvent).resolves.toBeTruthy();
     });
 
     test("should be able to cancel a pointer decision with the escape key", async ({ fixture }) => {

--- a/src/components/decision/decision.ts
+++ b/src/components/decision/decision.ts
@@ -206,7 +206,7 @@ export abstract class DecisionComponent extends AbstractComponent(LitElement) {
       disabled: !!this.disabled,
       "show-decision-color": this.isShowingDecisionColor(),
       "cancel-next": !this.shouldEmitNext,
-      [`decision-${this.decisionId}`]: true,
+      [`decision-${this.decisionId}`]: this.verified !== DecisionOptions.SKIP,
     });
 
     return html`

--- a/src/components/info-card/info-card.ts
+++ b/src/components/info-card/info-card.ts
@@ -16,13 +16,13 @@ type InfoCardTemplate = (value: any) => any;
 export class InfoCardComponent extends AbstractComponent(LitElement) {
   public static styles = unsafeCSS(infoCardStyle);
 
-  /** Number of subject key/values pairs to show before the "Show More" button is clicked */
-  @property({ attribute: "default-lines", type: Number, reflect: true })
-  public defaultLines = 3;
-
   @consume({ context: gridTileContext, subscribe: true })
   @property({ attribute: false })
   public model?: SubjectWrapper;
+
+  /** Number of subject key/values pairs to show before the "Show More" button is clicked */
+  @property({ attribute: "default-lines", type: Number, reflect: true })
+  public defaultLines = 3;
 
   @state()
   private showExpanded = false;

--- a/src/components/verification-grid-tile/css/style.css
+++ b/src/components/verification-grid-tile/css/style.css
@@ -75,3 +75,58 @@
   background-color: var(--oe-panel-color);
   border-radius: var(--oe-border-rounding);
 }
+
+.progress-meter {
+  --progress-meter-rounding: var(--oe-border-rounding);
+
+  display: flex;
+  height: var(--oe-spacing);
+  width: 100%;
+  border: var(--oe-border-width) solid var(--oe-border-color);
+  border-radius: var(--progress-meter-rounding);
+
+  /*
+    Only apply spacing to the top and bottom of the progress meter because we
+    want the progress meter to be vertically aligned to all the other elements
+    in the verification grid tile.
+  */
+  margin-top: var(--oe-spacing);
+  margin-bottom: var(--oe-spacing);
+}
+
+.progress-meter-segment {
+  flex: 1 0;
+
+  /* This default background will be overwritten if a decision is applied */
+  background-color: var(--oe-undecided-color);
+}
+
+/*
+  We use a border-right to separate each progress-meter-item. But we do not want
+  to use a border-right on the last item because it would result in a double
+  border on the last item. One from the progress-meter-item and one from the
+  progress-meter itself.
+*/
+:not(:last-child) > .progress-meter-segment {
+  border-right: var(--oe-border-width) solid var(--oe-border-color);
+}
+
+/*
+  We apply the same amount of rounding to each progress meter item that was
+  applied to the progress meter so that the first and last items are flush with
+  the progress meter.
+  If we did not round the first and last items, they would have a sharp edge
+  and cause the inner edge of the border to not be the same radius as the outer
+  borders edge.
+  We don't round every edge because we want the individual items to be separated
+  with a straight edge.
+*/
+:first-child > .progress-meter-segment {
+  border-top-left-radius: var(--progress-meter-rounding);
+  border-bottom-left-radius: var(--progress-meter-rounding);
+}
+
+:last-child > .progress-meter-segment {
+  border-top-right-radius: var(--progress-meter-rounding);
+  border-bottom-right-radius: var(--progress-meter-rounding);
+}

--- a/src/helpers/themes/theming.css
+++ b/src/helpers/themes/theming.css
@@ -67,6 +67,8 @@
   --oe-font-color-lighter: color-mix(in srgb, var(--oe-font-color) 10%, var(--oe-background-color));
   --oe-panel-color-lighter: color-mix(in srgb, var(--oe-panel-color) 1%, var(--oe-background-color));
 
+  --oe-undecided-color: var(--oe-panel-color);
+
   /* Breakpoints */
   --oe-mobile-breakpoint: 600px;
 }

--- a/src/tests/helpers.ts
+++ b/src/tests/helpers.ts
@@ -33,6 +33,12 @@ export async function getBrowserStyles<T extends HTMLElement>(component: Locator
   });
 }
 
+export async function getCssVariable<T extends HTMLElement>(locator: Locator, name: string): Promise<string> {
+  return await locator.evaluate((element: T, variable: string) => {
+    return window.getComputedStyle(element).getPropertyValue(variable);
+  }, name);
+}
+
 export async function emitBrowserEvent<T extends HTMLElement>(locator: Locator, eventName: string) {
   return locator.evaluate((element: T, name: string) => {
     const event = new Event(name, { bubbles: true });


### PR DESCRIPTION
# Show completed actions in segmented meter

## Changes

### Features

- Adds a segmented meter to each grid tile which displays what tasks have or have not been completed for the given tile

### Bug Fixes

- Fixes some leaky tests in `decision.spec.ts` which could cause other tests to incorrectly fail
- Do not show a decision highlight for a skip decision
- Fix a bug where [Object object] would be shown in the tile figure title if there was no `tag` column in the dataset

### Code Quality

- Remove empty `.gitkeep` file from e2e test folder (`/e2e/`)
- Adds `tag` column to the verification grid test dataset
- Re-order some info-cards properties to reflect the code-style.md (context's should come first)
- `RequiredClassificationTags` no longer returns duplicate tag models

This was originally here because we did not have any e2e tests, but still wanted the directory to exist so that Playwright would not throw an error "could not find directory tests/" when running in CI.

### Remaining Bugs / Unresolved Problems

## Visual Changes

![segmented meter](https://github.com/user-attachments/assets/4f66b379-9bcf-43ec-ab05-1a9de7374ca8)

_A progress meter showing the hover tooltip_

## Documentation Examples

<https://66cd28fa0d24d7546b7bee44--oe-web-components.netlify.app/examples/verification/classification/>

## Related Issues

Fixes: #134 

## Final Checklist

- [ ] All commits messages are semver compliant
- [x] Added relevant unit tests for new functionality
- [x] Updated existing unit tests to reflect changes
- [x] Code style is consistent with the project guidelines
- [x] Documentation is updated to reflect the changes (if applicable)
- [x] Link issues related to the PR
- [x] Assign labels if you have permission
- [x] Assign reviewers if you have permission
- [x] Ensure that CI is passing
- [x] Ensure that `pnpm lint` runs without any errors
- [x] Ensure that `pnpm test` runs without any errors
