### PR TITLE
Fix: Icons not being included in production build

### DIFF
--- a/dev/verification-grid.html
+++ b/dev/verification-grid.html
@@ -8,7 +8,7 @@
   </head>
 
   <body>
-    <oe-verification-grid id="verification-grid" grid-size="8" axes="false" indicator="false" media-controls="false">
+    <oe-verification-grid id="verification-grid">
       <template>
         <oe-info-card></oe-info-card>
       </template>

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "prismjs": "^1.29.0"
   },
   "devDependencies": {
-    "@11ty/eleventy": "3.0.0-alpha.10",
+    "@11ty/eleventy": "3.0.0-beta.1",
     "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.0",
     "@custom-elements-manifest/analyzer": "^0.9.4",
     "@playwright/test": "1.46.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         version: 1.29.0
     devDependencies:
       '@11ty/eleventy':
-        specifier: 3.0.0-alpha.10
-        version: 3.0.0-alpha.10
+        specifier: 3.0.0-beta.1
+        version: 3.0.0-beta.1
       '@11ty/eleventy-plugin-syntaxhighlight':
         specifier: ^5.0.0
         version: 5.0.0
@@ -154,8 +154,8 @@ packages:
     resolution: {integrity: sha512-nULO91om7vQw4Y/UBjM8i7nJ1xl+/nyK4rImZ41lFxiY2d+XUz7ChAj1CDYFjrLZeu0utAYJTZ45LlcHTkUG4g==}
     engines: {node: '>=12'}
 
-  '@11ty/eleventy@3.0.0-alpha.10':
-    resolution: {integrity: sha512-lnymV2KjhxPNs+e4otrjwr/kh7AEE/yTAwgVRtpdo8BA+zSDHaw+aeq/2L+h2nhQ9Z1a4ExIjQqk7K51E40tlA==}
+  '@11ty/eleventy@3.0.0-beta.1':
+    resolution: {integrity: sha512-iJT7vekH11l8PAUPBfUAcb5oWbYK0w4ijgwDTutUsk6tX9rp4ZRL1jdhVWvZq04/rkc55mczNFPPhHB/XO1/qw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -166,6 +166,9 @@ packages:
   '@11ty/posthtml-urls@1.0.0':
     resolution: {integrity: sha512-CcsRdI933x613u7CjM+QGs7iD/m8SaDup3Apohg1+7dybigrEUHc2jGS3mcMgQKvF2+IphqmepD/FrKLlPkPEg==}
     engines: {node: '>= 6'}
+
+  '@11ty/recursive-copy@3.0.0':
+    resolution: {integrity: sha512-v1Mr7dWx5nk69/HRRtDHUYDV9N8+cE12IGiKSFOwML7HjOzUXwTP88e3cGuhqoVstkBil1ZEIaOB0KPP1zwqXA==}
 
   '@babel/helper-string-parser@7.24.8':
     resolution: {integrity: sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==}
@@ -895,10 +898,6 @@ packages:
     resolution: {integrity: sha512-LeZY+DZDRnvP7eMuQ6LHfCzUGxAAIViUBliK24P3hWXL6y4SortgR6Nim6xrkfSLlmH0+k+9NYNwVC2s53ZrYQ==}
     engines: {node: '>=0.10.0'}
 
-  array-differ@4.0.0:
-    resolution: {integrity: sha512-Q6VPTLMsmXZ47ENG3V+wQyZS1ZxXMxFyYzA+Z/GMrJ6yIutAIEf9wTyroTzmGjNfox9/h3GdGBCVh43GVFx4Uw==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   array-union@1.0.2:
     resolution: {integrity: sha512-Dxr6QJj/RdU/hCaBjOfxW+q6lyuVE6JFWIrAUpuOOhoJJoQ99cUn3igRaHVB5P9WrgFVN0FfArM3x0cueOU8ng==}
     engines: {node: '>=0.10.0'}
@@ -906,10 +905,6 @@ packages:
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
-
-  array-union@3.0.1:
-    resolution: {integrity: sha512-1OvF9IbWwaeiM9VhzYXVQacMibxpXOMYVNIvMtKRyX9SImBXpKcFr8XvFDeEslCyuH/t6KRt7HEO94AlP8Iatw==}
-    engines: {node: '>=12'}
 
   array-uniq@1.0.3:
     resolution: {integrity: sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==}
@@ -1059,6 +1054,9 @@ packages:
 
   change-case@5.4.4:
     resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
+
+  chardet@2.0.0:
+    resolution: {integrity: sha512-xVgPpulCooDjY6zH4m9YW3jbkaBe3FKIAvF5sj5t7aBNsVl2ljIE+xwJ4iNgiDZHFQvNIpjdKdVOQvvk5ZfxbQ==}
 
   chokidar@3.5.2:
     resolution: {integrity: sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==}
@@ -1950,8 +1948,9 @@ packages:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  mkdirp@0.5.6:
-    resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
+  mkdirp@3.0.1:
+    resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
+    engines: {node: '>=10'}
     hasBin: true
 
   moo@0.5.2:
@@ -1968,10 +1967,6 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
-
-  multimatch@7.0.0:
-    resolution: {integrity: sha512-SYU3HBAdF4psHEL/+jXDKHO95/m5P2RvboHT2Y0WtTttvJLP4H/2WS9WlQPFvF6C8d6SpLw8vjCnQOnVIVOSJQ==}
-    engines: {node: '>=18'}
 
   music-metadata-browser@2.5.11:
     resolution: {integrity: sha512-Khq5nYapffIet0PUVb5J69pZPgqgn+/yoEr0jkO/OjH5xwfdz6rdwj0zsWPaqo3ylv+OthXoGjT6EegVHbMkJQ==}
@@ -2175,6 +2170,12 @@ packages:
     resolution: {integrity: sha512-TesUflQ0WKZqAvg52PWL6kHgLKP6xB6heTOdoYM0Wt2UHyxNa4K25EZZMgKns3BH1RLVbZCREPpLY0rhnNoHVQ==}
     engines: {node: ^10 || ^12 || >=14}
 
+  posthtml-match-helper@2.0.2:
+    resolution: {integrity: sha512-ehnazjlSwcGa3P2LlFYmTmcnaembTSt9dLWIRRDVHDPidf6InWAr9leKeeLvUXgnU32g6BrFS64Je+c2Ld+l9g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      posthtml: ^0.16.6
+
   posthtml-parser@0.11.0:
     resolution: {integrity: sha512-QecJtfLekJbWVo/dMAA+OSwY79wpRmbqS5TeXvXSX+f0c6pW4/SE6inzZ2qkU7oAMCPqIDkZDvd/bQsSFUnKyw==}
     engines: {node: '>=12'}
@@ -2273,9 +2274,6 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
-  recursive-copy@2.0.14:
-    resolution: {integrity: sha512-K8WNY8f8naTpfbA+RaXmkaQuD1IeW9EgNEfyGxSqqTQukpVtoOKros9jUqbpEsSw59YOmpd8nCBgtqJZy5nvog==}
-
   regenerator-runtime@0.14.1:
     resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
 
@@ -2298,11 +2296,6 @@ packages:
   reusify@1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
-
-  rimraf@2.7.1:
-    resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
-    deprecated: Rimraf versions prior to v4 are no longer supported
-    hasBin: true
 
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
@@ -2811,7 +2804,7 @@ snapshots:
     dependencies:
       normalize-path: 3.0.0
 
-  '@11ty/eleventy@3.0.0-alpha.10':
+  '@11ty/eleventy@3.0.0-beta.1':
     dependencies:
       '@11ty/dependency-tree': 3.0.1
       '@11ty/dependency-tree-esm': 1.0.0
@@ -2820,17 +2813,21 @@ snapshots:
       '@11ty/eleventy-utils': 1.0.3
       '@11ty/lodash-custom': 4.17.21
       '@11ty/posthtml-urls': 1.0.0
+      '@11ty/recursive-copy': 3.0.0
       '@sindresorhus/slugify': 2.2.1
       bcp-47-normalize: 2.3.0
+      chardet: 2.0.0
       chokidar: 3.6.0
       cross-spawn: 7.0.3
       debug: 4.3.6
       dependency-graph: 1.0.0
       fast-glob: 3.3.2
+      filesize: 10.1.4
       graceful-fs: 4.2.11
       gray-matter: 4.0.3
       is-glob: 4.0.3
       iso-639-1: 3.1.2
+      js-yaml: 4.1.0
       kleur: 4.1.5
       liquidjs: 10.16.3
       luxon: 3.5.0
@@ -2838,13 +2835,12 @@ snapshots:
       micromatch: 4.0.7
       minimist: 1.2.8
       moo: 0.5.2
-      multimatch: 7.0.0
       node-retrieve-globals: 6.0.0
       normalize-path: 3.0.0
       nunjucks: 3.2.4(chokidar@3.6.0)
       please-upgrade-node: 3.2.0
       posthtml: 0.16.6
-      recursive-copy: 2.0.14
+      posthtml-match-helper: 2.0.2(posthtml@0.16.6)
       semver: 7.6.3
       slugify: 1.6.6
     transitivePeerDependencies:
@@ -2861,6 +2857,18 @@ snapshots:
       list-to-array: 1.1.0
       object.entries: 1.1.8
       parse-srcset: 1.0.2
+
+  '@11ty/recursive-copy@3.0.0':
+    dependencies:
+      errno: 0.1.8
+      graceful-fs: 4.2.11
+      junk: 1.0.3
+      maximatch: 0.1.0
+      mkdirp: 3.0.1
+      pify: 2.3.0
+      promise: 7.3.1
+      rimraf: 5.0.10
+      slash: 1.0.0
 
   '@babel/helper-string-parser@7.24.8': {}
 
@@ -3541,15 +3549,11 @@ snapshots:
 
   array-differ@1.0.0: {}
 
-  array-differ@4.0.0: {}
-
   array-union@1.0.2:
     dependencies:
       array-uniq: 1.0.3
 
   array-union@2.1.0: {}
-
-  array-union@3.0.1: {}
 
   array-uniq@1.0.3: {}
 
@@ -3738,6 +3742,8 @@ snapshots:
       supports-color: 7.2.0
 
   change-case@5.4.4: {}
+
+  chardet@2.0.0: {}
 
   chokidar@3.5.2:
     dependencies:
@@ -4701,9 +4707,7 @@ snapshots:
 
   minipass@7.1.2: {}
 
-  mkdirp@0.5.6:
-    dependencies:
-      minimist: 1.2.8
+  mkdirp@3.0.1: {}
 
   moo@0.5.2: {}
 
@@ -4714,12 +4718,6 @@ snapshots:
   ms@2.1.2: {}
 
   ms@2.1.3: {}
-
-  multimatch@7.0.0:
-    dependencies:
-      array-differ: 4.0.0
-      array-union: 3.0.1
-      minimatch: 9.0.5
 
   music-metadata-browser@2.5.11:
     dependencies:
@@ -4948,6 +4946,10 @@ snapshots:
       picocolors: 1.0.1
       source-map-js: 1.2.0
 
+  posthtml-match-helper@2.0.2(posthtml@0.16.6):
+    dependencies:
+      posthtml: 0.16.6
+
   posthtml-parser@0.11.0:
     dependencies:
       htmlparser2: 7.2.0
@@ -5047,18 +5049,6 @@ snapshots:
     dependencies:
       picomatch: 2.3.1
 
-  recursive-copy@2.0.14:
-    dependencies:
-      errno: 0.1.8
-      graceful-fs: 4.2.11
-      junk: 1.0.3
-      maximatch: 0.1.0
-      mkdirp: 0.5.6
-      pify: 2.3.0
-      promise: 7.3.1
-      rimraf: 2.7.1
-      slash: 1.0.0
-
   regenerator-runtime@0.14.1: {}
 
   require-directory@2.1.1: {}
@@ -5074,10 +5064,6 @@ snapshots:
       supports-preserve-symlinks-flag: 1.0.0
 
   reusify@1.0.4: {}
-
-  rimraf@2.7.1:
-    dependencies:
-      glob: 7.2.3
 
   rimraf@3.0.2:
     dependencies:

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,7 +1,8 @@
 // we import the polyfills first so that they are available when the components
 // are imported
-import { setBasePath } from "@shoelace-style/shoelace";
 import "../polyfills/polyfills";
+import { registerBundledIcons } from "../services/shoelaceLoader";
+registerBundledIcons();
 
 // oe web components barrel file
 export * from "./media-controls/media-controls";
@@ -25,4 +26,3 @@ export * from "./verification-grid-settings/verification-grid-settings";
 // import "@shoelace-style/shoelace/dist/components/dropdown/dropdown.js";
 // import "@shoelace-style/shoelace/dist/components/button/button.js";
 import "@shoelace-style/shoelace";
-setBasePath("/node_modules/@shoelace-style/shoelace/dist");

--- a/src/components/media-controls/css/style.css
+++ b/src/components/media-controls/css/style.css
@@ -12,13 +12,7 @@ sl-menu-item[checked]::part(base) {
   color: var(--oe-font-color);
 }
 
-/*
-  The play/pause icons provided by shoelace look smaller than the rest of the
-  icons which are in the media controls.
-  By increasing the size of the play/pause icons, we can make them fit in more.
-*/
-sl-icon[name="play"],
-sl-icon[name="pause"] {
+sl-icon.large-icon {
   --enlargement-factor: 1.5;
 
   /*

--- a/src/components/media-controls/media-controls.ts
+++ b/src/components/media-controls/media-controls.ts
@@ -140,7 +140,7 @@ export class MediaControlsComponent extends AbstractComponent(LitElement) {
   private playIcon() {
     return html`
       <slot name="play-icon" part="play-icon">
-        <sl-icon name="play"></sl-icon>
+        <sl-icon name="play" class="large-icon"></sl-icon>
       </slot>
     `;
   }
@@ -148,7 +148,7 @@ export class MediaControlsComponent extends AbstractComponent(LitElement) {
   private pauseIcon() {
     return html`
       <slot name="pause-icon" part="pause-icon">
-        <sl-icon name="pause"></sl-icon>
+        <sl-icon name="pause" class="large-icon"></sl-icon>
       </slot>
     `;
   }

--- a/src/components/spectrogram/spectrogram.spec.ts
+++ b/src/components/spectrogram/spectrogram.spec.ts
@@ -26,7 +26,7 @@ test.describe("unit tests", () => {
     expect(outside).toEqual({ keyboardShortcut: false, play: false });
   });
 
-  test("loading events", async ({ mount }) => {
+  test("loading events", async ({ mount, page }) => {
     let loadingEvent: CustomEvent | undefined;
     let loadedEvent: CustomEvent | undefined;
 
@@ -45,6 +45,9 @@ test.describe("unit tests", () => {
     });
 
     await setBrowserAttribute<SpectrogramComponent>(component, "src", "/example2.flac");
+
+    // TODO: this is a hacky way to wait for the loading event to fire, there should be a better way
+    await page.waitForTimeout(1000);
 
     expect(loadingEvent).toBeDefined();
     expect(loadedEvent).toBeDefined();

--- a/src/components/verification-grid-settings/verification-grid-settings.ts
+++ b/src/components/verification-grid-settings/verification-grid-settings.ts
@@ -135,7 +135,7 @@ export class VerificationGridSettingsComponent extends SignalWatcher(AbstractCom
           aria-label="${buttonLabel}"
         >
           <sl-icon
-            name="${this.settings.isFullscreen.value ? "fullscreen-exit" : "arrows-fullscreen"}"
+            name="${this.settings.isFullscreen.value ? "fullscreen-exit " : "arrows-fullscreen"}"
             class="large-icon"
           ></sl-icon>
         </button>

--- a/src/services/shoelaceLoader.ts
+++ b/src/services/shoelaceLoader.ts
@@ -1,0 +1,38 @@
+import { registerIconLibrary } from "@shoelace-style/shoelace";
+import circleHalfIcon from "../../node_modules/@shoelace-style/shoelace/dist/assets/icons/circle-half.svg?raw";
+import playIcon from "../../node_modules/@shoelace-style/shoelace/dist/assets/icons/play.svg?raw";
+import pauseIcon from "../../node_modules/@shoelace-style/shoelace/dist/assets/icons/pause.svg?raw";
+import paletteIcon from "../../node_modules/@shoelace-style/shoelace/dist/assets/icons/palette.svg?raw";
+import gearIcon from "../../node_modules/@shoelace-style/shoelace/dist/assets/icons/gear.svg?raw";
+import brightnessHighIcon from "../../node_modules/@shoelace-style/shoelace/dist/assets/icons/brightness-high.svg?raw";
+import questionCircleIcon from "../../node_modules/@shoelace-style/shoelace/dist/assets/icons/question-circle.svg?raw";
+import fullscreenExitIcon from "../../node_modules/@shoelace-style/shoelace/dist/assets/icons/fullscreen-exit.svg?raw";
+import arrowsFullscreenIcon from "../../node_modules/@shoelace-style/shoelace/dist/assets/icons/arrows-fullscreen.svg?raw";
+import gridIcon from "../../node_modules/@shoelace-style/shoelace/dist/assets/icons/grid.svg?raw";
+
+type InlineSvg = `data:image/svg+xml,${string}`;
+
+// to use an icon inside <sl-icon>, you will need to register the icon below
+// if icon is not registered, the <sl-icon> will not have any content
+const registeredIcons: Record<string, string> = {
+  "circle-half": circleHalfIcon,
+  "brightness-high": brightnessHighIcon,
+  "question-circle": questionCircleIcon,
+  "fullscreen-exit": fullscreenExitIcon,
+  "arrows-fullscreen": arrowsFullscreenIcon,
+  play: playIcon,
+  pause: pauseIcon,
+  palette: paletteIcon,
+  gear: gearIcon,
+  grid: gridIcon,
+};
+
+export function registerBundledIcons() {
+  registerIconLibrary("default", {
+    resolver: (name: keyof typeof registeredIcons): InlineSvg => inlineSvg(registeredIcons[name]),
+  });
+}
+
+function inlineSvg(source: string): InlineSvg {
+  return `data:image/svg+xml,${source}`;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     VitePluginCustomElementsManifest({
       files: ["./src/components/**/*.ts"],
       lit: true,
-    }) as any,
+    }),
     nodePolyfills(),
     svgLoader(),
     // mkcert(),
@@ -60,4 +60,4 @@ export default defineConfig({
       formats: ["es"],
     },
   },
-} as any);
+});


### PR DESCRIPTION
# Fix: Icons not being included in the production build

Previously, shoelace icons were not bundled during a production build, meaning that the media controls and other similar locations would have an empty placeholder where the icon should be.

This PR adds the shoelace icons to the production build by assigning each icon's SVG to a variable in the bundle's barrel file.

I have chosen this solution because

- We have to support offline usage (meaning that we can't use a CDN), and all assets must be included in the build
- I inlined the SVGs into the barrel file because shipping an additional dependency (in the form of a seperate SVG file in the `assets/` directory) increases the complexity of deploying the web components because it requires you to: correctly set up CORS for this external file, serve the external file with the correct MIME type, permissions, etc... By inlining it into the single barrel file, there is no additional overhead to using the web components

## Changes

### Features

N.A.

### Bug Fixes

- Fixes shoelace icons not being included in the production build

### Code Quality

N.A.

### Remaining Bugs / Unresolved Problems

## Visual Changes

![image](https://github.com/user-attachments/assets/aa4454ec-313f-4b7f-aaaf-f0fc08ffa4e0)

_Icons remain unchanged, but I have included a screenshot in case you can spot any discrepancies_

## Documentation Examples

<https://66cd6037baf6ea88c3fb7d86--oe-web-components.netlify.app/examples/verification/single/>

## Related Issues

Fixes: #98 

## Additional Notes

## Final Checklist

- [x] All commits messages are semver compliant
- [ ] Added relevant unit tests for new functionality
- [ ] Updated existing unit tests to reflect changes
- [x] Code style is consistent with the project guidelines
- [x] Documentation is updated to reflect the changes (if applicable)
- [x] Link issues related to the PR
- [x] Assign labels if you have permission
- [x] Assign reviewers if you have permission
- [x] Ensure that CI is passing
- [x] Ensure that `pnpm lint` runs without any errors
- [x] Ensure that `pnpm test` runs without any errors
