### PR TITLE
Add a progress bar to show dataset progress

### DIFF
--- a/src/components/axes/css/style.css
+++ b/src/components/axes/css/style.css
@@ -13,7 +13,7 @@
 svg {
   position: absolute;
   width: 100%;
-  height: 100%;
+  height: auto;
   overflow: visible;
 
   /*

--- a/src/components/data-source/data-source.ts
+++ b/src/components/data-source/data-source.ts
@@ -212,6 +212,7 @@ export class DataSourceComponent extends AbstractComponent(LitElement) {
         return {
           subjects: [],
           context,
+          totalItems: content.length,
         };
       }
 
@@ -231,6 +232,7 @@ export class DataSourceComponent extends AbstractComponent(LitElement) {
       return {
         subjects,
         context,
+        totalItems: content.length,
       };
     };
   }

--- a/src/components/decision/classification/classification.ts
+++ b/src/components/decision/classification/classification.ts
@@ -155,6 +155,7 @@ export class ClassificationComponent extends DecisionComponent {
         part="${decision}-decision-button"
         title="Shortcut: ${shortcut}"
         style="--ripple-color: var(${color})"
+        aria-label="${decision} decision for ${this.tag.text}"
         aria-disabled="${this.disabled}"
         @click="${() => this.emitDecision([decisionModel])}"
       >

--- a/src/components/decision/css/style.css
+++ b/src/components/decision/css/style.css
@@ -3,6 +3,15 @@
   height: 100%;
   padding: 0.3em;
 
+  kbd {
+    /*
+      Even though we are using a monospaced font, some utf8 symbols such as the
+      shift key icon are taller than other characters
+      To fix this, I make each keyboard element the same height.
+    */
+    height: 1rem;
+  }
+
   > div {
     display: block;
 

--- a/src/components/decision/decision.ts
+++ b/src/components/decision/decision.ts
@@ -13,9 +13,9 @@ import {
 import { ClassificationComponent } from "./classification/classification";
 import { VerificationComponent } from "./verification/verification";
 import { consume } from "@lit/context";
-import decisionStyles from "./css/style.css?inline";
 import { decisionColor } from "../../services/colors";
 import { KeyboardShortcut } from "verification-grid/help-dialog";
+import decisionStyles from "./css/style.css?inline";
 
 interface DecisionContent {
   value: Decision[];

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -19,6 +19,7 @@ export * from "./decision/decision";
 export * from "./decision/classification/classification";
 export * from "./decision/verification/verification";
 export * from "./verification-grid-settings/verification-grid-settings";
+export * from "./progress-bar/progress-bar";
 
 // TODO: cherry pick shoelace components
 // see: https://github.com/ecoacoustics/web-components/issues/83

--- a/src/components/indicator/css/style.css
+++ b/src/components/indicator/css/style.css
@@ -29,7 +29,7 @@
 #indicator-svg {
   position: absolute;
   /* width: 100%; */
-  height: 100%;
+  height: auto;
   z-index: 1;
   overflow: visible;
 }

--- a/src/components/progress-bar/css/style.css
+++ b/src/components/progress-bar/css/style.css
@@ -1,0 +1,29 @@
+.progress-bar {
+  display: flex;
+  position: relative;
+  height: var(--oe-font-size);
+  background-color: var(--oe-panel-color);
+  border-radius: var(--oe-border-rounding);
+  margin-top: var(--oe-spacing-large);
+
+  .segment {
+    height: 100%;
+    width: 100%;
+    border-radius: var(--oe-border-rounding);
+
+    &.head-segment {
+      background-color: var(--oe-secondary-color);
+      z-index: 1;
+    }
+
+    &.completed-segment {
+      background-color: var(--oe-selected-color);
+
+      &.offset-segment {
+        position: relative;
+        left: calc(-1 * var(--oe-border-rounding));
+        border-left: var(--oe-border-rounding) solid var(--oe-selected-color);
+      }
+    }
+  }
+}

--- a/src/components/progress-bar/progress-bar.ts
+++ b/src/components/progress-bar/progress-bar.ts
@@ -1,0 +1,93 @@
+import { customElement, property } from "lit/decorators.js";
+import { AbstractComponent } from "../../mixins/abstractComponent";
+import { html, LitElement, TemplateResult, unsafeCSS } from "lit";
+import progressBarStyles from "./css/style.css?inline";
+import { when } from "lit/directives/when.js";
+import { classMap } from "lit/directives/class-map.js";
+
+/**
+ * @description
+ * A progress bar that indicates how far through a task you are.
+ */
+@customElement("oe-progress-bar")
+export class ProgressBar extends AbstractComponent(LitElement) {
+  public static styles = unsafeCSS(progressBarStyles);
+
+  /** Where the verification head is at */
+  @property({ attribute: "history-head", type: Number })
+  public historyHead = 0;
+
+  /** The total number of items in the data set */
+  @property({ type: Number })
+  public total?: number;
+
+  /** The completion head */
+  @property({ type: Number })
+  public completed = 0;
+
+  private segmentLength(value: number): number {
+    if (!this.total || this.total < 0) {
+      // if the paging callback does not provide a total number of items, we
+      // use a logarithmic function that does not reach 100%
+      // https://www.wolframalpha.com/input?i=0.99+-+e%5E%28-0.03x%29+from+0+to+300
+      //
+      // we use 0.99 as the maximum so that  the progress bar will never reach
+      // 100% even with fractional rounding
+      // using an exponent multiple of -0.03 means that we can have a (realistic)
+      // maximum of up to 170 items
+      const logarithmicFunction = (x: number) => 0.99 - Math.E ** (-0.03 * x);
+
+      // because the logarithmic function returns a value from 0 to 1
+      // we multiply the logarithmic function value by 100 to get a percentage
+      return logarithmicFunction(value) * 100;
+    }
+
+    const percentagePerValue = 100 / this.total;
+    const x = value * percentagePerValue;
+    console.log(x);
+    return x;
+  }
+
+  public render(): TemplateResult {
+    const completedPercentage = this.segmentLength(this.completed);
+    const viewHeadPercentage = this.segmentLength(this.historyHead);
+    const viewHeadPercentageDelta = completedPercentage - viewHeadPercentage;
+    const isViewingHistory = this.historyHead < this.completed;
+
+    const completedTooltip = `${this.completed} / ${this.total} (${completedPercentage.toPrecision(2)}%) audio segments completed${isViewingHistory ? " (viewing history)" : ""}`;
+    const viewHeadHistoryTooltip = `Viewing history from segment ${this.historyHead} / ${this.total} (${viewHeadPercentage.toPrecision(2)}%)`;
+
+    const completedSegmentClasses = classMap({
+      "offset-segment": viewHeadPercentage > 0,
+    });
+
+    // prettier-ignore
+    return html`
+      <div role="progressbar" class="progress-bar">
+        ${when(viewHeadPercentage > 0, () => html`
+          <sl-tooltip
+            content="${isViewingHistory ? viewHeadHistoryTooltip : completedTooltip}"
+            data-testid="view-head-tooltip"
+          >
+            <span class="segment head-segment" style="width: ${viewHeadPercentage}%"></span>
+          </sl-tooltip>
+        `)}
+
+        ${when(viewHeadPercentageDelta > 0, () => html`
+          <sl-tooltip content="${completedTooltip}" data-testid="completed-tooltip">
+            <span
+              class="segment completed-segment ${completedSegmentClasses}"
+              style="width: ${viewHeadPercentageDelta}%"
+            ></span>
+          </sl-tooltip>
+        `)}
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "oe-progress-bar": ProgressBar;
+  }
+}

--- a/src/components/progress-bar/progress-bar.ts
+++ b/src/components/progress-bar/progress-bar.ts
@@ -43,9 +43,7 @@ export class ProgressBar extends AbstractComponent(LitElement) {
     }
 
     const percentagePerValue = 100 / this.total;
-    const x = value * percentagePerValue;
-    console.log(x);
-    return x;
+    return value * percentagePerValue;
   }
 
   public render(): TemplateResult {
@@ -54,8 +52,10 @@ export class ProgressBar extends AbstractComponent(LitElement) {
     const viewHeadPercentageDelta = completedPercentage - viewHeadPercentage;
     const isViewingHistory = this.historyHead < this.completed;
 
-    const completedTooltip = `${this.completed} / ${this.total} (${completedPercentage.toPrecision(2)}%) audio segments completed${isViewingHistory ? " (viewing history)" : ""}`;
-    const viewHeadHistoryTooltip = `Viewing history from segment ${this.historyHead} / ${this.total} (${viewHeadPercentage.toPrecision(2)}%)`;
+    console.log("completed", completedPercentage);
+
+    const completedTooltip = `${this.completed} / ${this.total} (${completedPercentage.toFixed(2)}%) audio segments completed${isViewingHistory ? " (viewing history)" : ""}`;
+    const viewHeadHistoryTooltip = `Viewing history from segment ${this.historyHead} / ${this.total} (${viewHeadPercentage.toFixed(2)}%)`;
 
     const completedSegmentClasses = classMap({
       "offset-segment": viewHeadPercentage > 0,

--- a/src/components/progress-bar/progrss-bar.fixture.ts
+++ b/src/components/progress-bar/progrss-bar.fixture.ts
@@ -1,0 +1,45 @@
+import { Page } from "@playwright/test";
+import { test } from "@sand4rt/experimental-ct-web";
+import { setBrowserAttribute } from "../../tests/helpers";
+import { ProgressBar } from "./progress-bar";
+
+class ProgressBarFixture {
+  public constructor(public readonly page: Page) {}
+
+  public component = () => this.page.locator("oe-progress-bar").first();
+  public completedSegment = () => this.page.locator(".completed-segment").first();
+  public viewHeadSegment = () => this.page.locator(".head-segment").first();
+
+  public async create() {
+    await this.page.setContent("<oe-progress-bar total='100' history-head='0' completed='0'></oe-progress-bar>");
+    await this.page.waitForLoadState("networkidle");
+    await this.page.waitForSelector("oe-progress-bar");
+  }
+
+  public async completedSegmentSize(): Promise<string> {
+    return await this.completedSegment().evaluate((element: HTMLSpanElement) => element.style.width);
+  }
+
+  public async viewHeadSegmentSize(): Promise<string> {
+    return await this.viewHeadSegment().evaluate((element: HTMLSpanElement) => element.style.width);
+  }
+
+  public async changeViewHead(value: number) {
+    await setBrowserAttribute<ProgressBar>(
+      this.component(),
+      "history-head" as keyof ProgressBar,
+      value.toString(),
+    );
+  }
+
+  public async changeCompletedHead(value: number) {
+    await setBrowserAttribute<ProgressBar>(this.component(), "completed", value.toString());
+  }
+}
+
+export const progressBarFixture = test.extend<{ fixture: ProgressBarFixture }>({
+  fixture: async ({ page }, run) => {
+    const fixture = new ProgressBarFixture(page);
+    await run(fixture);
+  },
+});

--- a/src/components/progress-bar/progrss-bar.spec.ts
+++ b/src/components/progress-bar/progrss-bar.spec.ts
@@ -1,0 +1,35 @@
+import { expect } from "../../tests/assertions";
+import { progressBarFixture as test } from "./progrss-bar.fixture";
+
+test.describe("ProgressBar", () => {
+  test.beforeEach(async ({ fixture }) => {
+    await fixture.create();
+  });
+
+  test("should not have a completed segment if there are no decisions", async ({ fixture }) => {
+    const completedSegments = await fixture.completedSegment().count();
+    expect(completedSegments).toBe(0);
+  });
+
+  test("should not have a view head segment if there are no decisions", async ({ fixture }) => {
+    const headSegments = await fixture.viewHeadSegment().count();
+    expect(headSegments).toBe(0);
+  });
+
+  test("should have the correct segment sizes when the view head and completed head is set", async ({ fixture }) => {
+    const viewHeadValue = 10;
+    const completedValue = 20;
+
+    await fixture.changeViewHead(viewHeadValue);
+    await fixture.changeCompletedHead(completedValue);
+
+    const expectedHeadSegmentSize = "10%";
+    const expectedCompletedHeadSize = "10%";
+
+    const headSegmentSize = await fixture.viewHeadSegmentSize();
+    const completedSegmentSize = await fixture.completedSegmentSize();
+
+    expect(headSegmentSize).toBe(expectedHeadSegmentSize);
+    expect(completedSegmentSize).toBe(expectedCompletedHeadSize);
+  });
+});

--- a/src/components/spectrogram/css/style.css
+++ b/src/components/spectrogram/css/style.css
@@ -6,13 +6,13 @@
   position: relative;
   background-color: var(--oe-panel-color-lighter);
   width: 100%;
-  height: 100%;
+  height: auto;
 }
 
 #spectrogram-container > canvas {
   position: relative;
   display: inherit;
-  height: 100%;
+  height: auto;
 
   /*
     We set the minimum height to 64 because the minimum FFT window size that

--- a/src/components/spectrogram/spectrogram.ts
+++ b/src/components/spectrogram/spectrogram.ts
@@ -111,6 +111,9 @@ export class SpectrogramComponent extends SignalWatcher(AbstractComponent(LitEle
   @query("#media-element")
   private mediaElement!: HTMLMediaElement;
 
+  @query("#spectrogram-container")
+  private spectrogramContainer!: HTMLDivElement;
+
   @query("canvas")
   private canvas!: HTMLCanvasElement;
 
@@ -393,6 +396,13 @@ export class SpectrogramComponent extends SignalWatcher(AbstractComponent(LitEle
     } else {
       this.canvas.style.width = "auto";
     }
+
+    // TODO: we should do this in CSS
+    // I have set the size manually here so because for an unknown reason, the
+    // spectrogram canvas' grow indefinitely when in a Playwright browser
+    // we should figure out why this is happening and properly do this with CSS
+    this.spectrogramContainer.style.width = `${size.width}px`;
+    this.spectrogramContainer.style.height = `${size.height}px`;
   }
 
   /**

--- a/src/components/spectrogram/spectrogram.ts
+++ b/src/components/spectrogram/spectrogram.ts
@@ -111,9 +111,6 @@ export class SpectrogramComponent extends SignalWatcher(AbstractComponent(LitEle
   @query("#media-element")
   private mediaElement!: HTMLMediaElement;
 
-  @query("#spectrogram-container")
-  private spectrogramContainer!: HTMLDivElement;
-
   @query("canvas")
   private canvas!: HTMLCanvasElement;
 
@@ -396,13 +393,6 @@ export class SpectrogramComponent extends SignalWatcher(AbstractComponent(LitEle
     } else {
       this.canvas.style.width = "auto";
     }
-
-    // TODO: we should do this in CSS
-    // I have set the size manually here so because for an unknown reason, the
-    // spectrogram canvas' grow indefinitely when in a Playwright browser
-    // we should figure out why this is happening and properly do this with CSS
-    this.spectrogramContainer.style.width = `${size.width}px`;
-    this.spectrogramContainer.style.height = `${size.height}px`;
   }
 
   /**

--- a/src/components/verification-grid-tile/css/style.css
+++ b/src/components/verification-grid-tile/css/style.css
@@ -19,15 +19,6 @@
   padding: var(--selected-border-size);
   background-color: var(--oe-panel-color);
 
-  /*
-    This is here so that if there is a bug in the verification grid tile
-    scaling, it will not result in a browser crash as a result of it
-    growing indefinitely.
-    I have only observed this in Playwright but I think it might be related
-    to: https://github.com/ecoacoustics/web-components/issues/78
-   */
-  max-height: 100vh;
-
   transition:
     border-color var(--oe-animation-time) ease-out,
     border-size var(--oe-animation-time) ease-out;

--- a/src/components/verification-grid/css/style.css
+++ b/src/components/verification-grid/css/style.css
@@ -65,19 +65,22 @@
   text-align: center;
   font-family: sans-serif;
   font-weight: normal;
-  font-size: 1.4rem;
+  font-size: 1rem;
   letter-spacing: 0em;
   color: var(--oe-font-color);
+  margin: var(--oe-spacing-large);
 }
 
 .verification-controls {
   display: flex;
   flex-wrap: wrap;
-  justify-content: space-around;
+  justify-content: space-between;
   align-items: end;
   padding: var(--oe-spacing);
   gap: var(--oe-spacing);
   color: var(--oe-font-color);
+  margin-left: 10%;
+  margin-right: 10%;
 }
 
 .decision-controls {
@@ -95,6 +98,10 @@
 .decision-controls-left,
 .decision-controls-right {
   display: flex;
+}
+
+.progress-bar {
+  flex: 1 1 100%;
 }
 
 .no-decisions-warning {

--- a/src/components/verification-grid/verification-grid.ts
+++ b/src/components/verification-grid/verification-grid.ts
@@ -24,6 +24,7 @@ import { when } from "lit/directives/when.js";
 import { hasCtrlLikeModifier } from "../../helpers/userAgent";
 import { decisionColor } from "../../services/colors";
 import verificationGridStyles from "./css/style.css?inline";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 export type SelectionObserverType = "desktop" | "tablet" | "default";
 
@@ -1080,43 +1081,43 @@ export class VerificationGridComponent extends AbstractComponent(LitElement) {
     return this.verificationDecisionElements.length > 0;
   }
 
-  private mixedTaskPromptTemplate(hasMultipleTiles: boolean, hasSubSelection: boolean): TemplateResult<1> {
+  private mixedTaskPromptTemplate(hasMultipleTiles: boolean, hasSubSelection: boolean) {
     if (hasSubSelection) {
       return html`<p>Make a decision about all of the selected audio segments</p>`;
     }
 
     if (hasMultipleTiles) {
-      return html`<p>Make a decision about all of the audio segments</p>`;
+      return "Make a decision about all of the audio segments";
     } else {
-      return html`<p>Make a decision about the shown audio segment</p>`;
+      return "Make a decision about the shown audio segment";
     }
   }
 
-  private classificationTaskPromptTemplate(hasMultipleTiles: boolean, hasSubSelection: boolean): TemplateResult<1> {
+  private classificationTaskPromptTemplate(hasMultipleTiles: boolean, hasSubSelection: boolean) {
     if (hasSubSelection) {
-      return html`<p>Apply labels to selected audio segments</p>`;
+      return "Apply labels to selected audio segments";
     }
 
     if (hasMultipleTiles) {
-      return html`<p>Classify all relevant audio segments</p>`;
+      return "Classify all relevant audio segments";
     } else {
-      return html`<p>Apply a classification to the audio segment</p>`;
+      return "Apply a classification to the audio segment";
     }
   }
 
-  private verificationTaskPromptTemplate(hasMultipleTiles: boolean, hasSubSelection: boolean): TemplateResult<1> {
+  private verificationTaskPromptTemplate(hasMultipleTiles: boolean, hasSubSelection: boolean) {
     if (hasSubSelection) {
-      return html`<p>Do all of the selected audio segments have the correct applied tag</p>`;
+      return "Do all of the selected audio segments have the correct applied tag";
     }
 
     if (hasMultipleTiles) {
-      return html`<p>Do all of the audio segments have the correct applied tag</p>`;
+      return "Do all of the audio segments have the correct applied tag";
     } else {
-      return html`<p>Does the show audio segment have the correct applied tag</p>`;
+      return "Does the show audio segment have the correct applied tag";
     }
   }
 
-  private decisionPromptTemplate(): TemplateResult<1> {
+  private decisionPromptTemplate() {
     const subSelection = this.currentSubSelection;
     const hasSubSelection = subSelection.length > 0;
     const hasMultipleTiles = this.gridSize > 1;
@@ -1132,23 +1133,15 @@ export class VerificationGridComponent extends AbstractComponent(LitElement) {
     // default prompt if we can't determine if it is a classification or
     // verification task
     if (hasSubSelection) {
-      return html`<p>Are all of the selected a</p>`;
+      return "Are all of the selected a";
     }
-    return html`<p>${hasMultipleTiles ? "Are all of these a" : "Is the shown spectrogram a"}</p>`;
+
+    return hasMultipleTiles ? "Are all of these a" : "Is the shown spectrogram a";
   }
 
   //#endregion
 
   //#region Templates
-
-  private statisticsTemplate(): TemplateResult<1> {
-    return html`
-      <div class="statistics-section">
-        <h2>Statistics</h2>
-        <p><span>Validated Items</span>: ${this.subjectHistory.length}</p>
-      </div>
-    `;
-  }
 
   private noItemsTemplate(): TemplateResult<1> {
     return html`
@@ -1282,9 +1275,14 @@ export class VerificationGridComponent extends AbstractComponent(LitElement) {
           <span class="decision-controls-right">
             <slot name="data-source"></slot>
           </span>
-        </div>
 
-        <div>${this.statisticsTemplate()}</div>
+          <oe-progress-bar
+            class="progress-bar"
+            history-head="${this.subjectHistory.length - this.historyHead}"
+            total="${ifDefined(this.paginationFetcher?.totalItems)}"
+            completed="${this.subjectHistory.length}"
+          ></oe-progress-bar>
+        </div>
       </div>
     `;
   }

--- a/src/helpers/audio/worker.ts
+++ b/src/helpers/audio/worker.ts
@@ -116,6 +116,8 @@ function drawSpectrogramOntoDestinationCanvas(_generation: number): void {
   destinationSurface.drawImage(spectrogramCanvas, 0, 0, destinationCanvas.width, destinationCanvas.height);
 
   // commit doesn't exist on chrome
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
   destinationSurface.commit && destinationSurface.commit();
 }
 

--- a/src/helpers/themes/theming.css
+++ b/src/helpers/themes/theming.css
@@ -119,13 +119,6 @@ kbd {
   margin: 0.5rem;
   width: max-content;
 
-  /*
-    Even though we are using a monospaced font, some utf8 symbols such as the
-    shift key icon are taller than other characters
-    To fix this, I make each keyboard element the same height.
-  */
-  height: 1rem;
-
   &::before {
     content: "";
     position: absolute;

--- a/src/services/gridPageFetcher.ts
+++ b/src/services/gridPageFetcher.ts
@@ -4,6 +4,7 @@ import { SubjectParser } from "./verificationParser";
 export interface IPageFetcherResponse<T> {
   subjects: SubjectWrapper[];
   context: T;
+  totalItems: number;
 }
 
 /**
@@ -20,7 +21,7 @@ export class GridPageFetcher {
     this.converter = SubjectParser;
   }
 
-  // by setting the page
+  public totalItems?: number;
   private pagingCallback: PageFetcher;
   private converter: SubjectParser;
   private subjectQueueBuffer: SubjectWrapper[] = [];
@@ -93,9 +94,10 @@ export class GridPageFetcher {
   // to a buffer that we can pull from when requesting results for the same
   // page
   private async fetchNextPage(): Promise<SubjectWrapper[]> {
-    const { subjects, context } = await this.pagingCallback(this.pagingContext);
+    const { subjects, context, totalItems } = await this.pagingCallback(this.pagingContext);
     const models = subjects.map(this.converter.parse);
 
+    this.totalItems = totalItems;
     this.pagingContext = context;
     this.subjectQueueBuffer.push(...models);
 

--- a/src/tests/axes-spectrogram/axes-spectrogram.e2e.spec.ts
+++ b/src/tests/axes-spectrogram/axes-spectrogram.e2e.spec.ts
@@ -21,16 +21,16 @@ test.describe("interactions between axes and spectrogram", () => {
       {
         spectrogramSize: { width: 1000, height: 1000 },
         expectedXStep: 0.1,
-        expectedYStep: 0.2,
+        expectedYStep: 0.5,
         expectedXTickCount: 51,
-        expectedYTickCount: 56,
+        expectedYTickCount: 23,
       },
       {
         spectrogramSize: { width: 500, height: 500 },
         expectedXStep: 0.2,
-        expectedYStep: 0.5,
+        expectedYStep: 1,
         expectedXTickCount: 26,
-        expectedYTickCount: 23,
+        expectedYTickCount: 12,
       },
       {
         spectrogramSize: { width: 1000, height: 500 },
@@ -42,9 +42,9 @@ test.describe("interactions between axes and spectrogram", () => {
       {
         spectrogramSize: { width: 500, height: 1000 },
         expectedXStep: 0.2,
-        expectedYStep: 0.2,
+        expectedYStep: 1,
         expectedXTickCount: 26,
-        expectedYTickCount: 56,
+        expectedYTickCount: 12,
       },
       {
         spectrogramSize: { width: 100, height: 100 },

--- a/src/tests/verification-grid/verification-grid.e2e.fixture.ts
+++ b/src/tests/verification-grid/verification-grid.e2e.fixture.ts
@@ -21,6 +21,7 @@ import {
   AxesComponent,
   DataSourceComponent,
   MediaControlsComponent,
+  ProgressBar,
   SpectrogramCanvasScale,
   VerificationGridTileComponent,
   VerificationHelpDialogComponent,
@@ -31,6 +32,7 @@ import { expect } from "../assertions";
 import { KeyboardModifiers } from "../../helpers/types/playwright";
 import { decisionColor } from "../../services/colors";
 import { CssVariable } from "../../helpers/types/advancedTypes";
+import { SlTooltip } from "@shoelace-style/shoelace";
 
 class TestPage {
   public constructor(public readonly page: Page) {}
@@ -68,6 +70,12 @@ class TestPage {
     (await this.gridTileProgressMeters())[index].locator(".progress-meter-segment").all();
   public gridTileProgressMeterTooltips = async (index = 0) =>
     (await this.gridTileProgressMeters())[index].locator("sl-tooltip").all();
+
+  public gridProgressBar = () => this.page.locator("oe-progress-bar").first();
+  public gridProgressBarCompletedTooltip = () => this.gridProgressBar().getByTestId("completed-tooltip").first();
+  public gridProgressBarViewHeadTooltip = () => this.gridProgressBar().getByTestId("view-head-tooltip").first();
+  public gridProgressCompletedSegment = () => this.gridProgressBar().locator(".completed-segment").first();
+  public gridProgressHeadSegment = () => this.gridProgressBar().locator(".head-segment").first();
 
   public mediaControlsComponent = async (index = 0) =>
     (await this.gridTileContainers())[index].locator("oe-media-controls").first();
@@ -255,6 +263,33 @@ class TestPage {
       const domMatrix = new DOMMatrix(styles.transform);
       return domMatrix[domMatrixTranslateXKey];
     });
+  }
+
+  public async progressBarCompletedSize() {
+    return await this.gridProgressCompletedSegment().evaluate((element: HTMLSpanElement) => element.style.width);
+  }
+
+  public async progressBarHeadSize() {
+    return await this.gridProgressHeadSegment().evaluate((element: HTMLSpanElement) => element.style.width);
+  }
+
+  public async progressBarValueToPercentage(value: number): Promise<string> {
+    const progressBar = this.gridProgressBar();
+
+    const maxValue = (await getBrowserValue<ProgressBar>(progressBar, "total")) as number;
+    const percentage = 100 * (value / maxValue);
+
+    return `${percentage}%`;
+  }
+
+  public async progressBarCompletedTooltip() {
+    const tooltip = this.gridProgressBarCompletedTooltip();
+    return await getBrowserValue<SlTooltip>(tooltip, "content");
+  }
+
+  public async progressBarViewHeadTooltip() {
+    const tooltip = this.gridProgressBarViewHeadTooltip();
+    return await getBrowserValue<SlTooltip>(tooltip, "content");
   }
 
   public async isViewingHistory(): Promise<boolean> {

--- a/src/tests/verification-grid/verification-grid.e2e.spec.ts
+++ b/src/tests/verification-grid/verification-grid.e2e.spec.ts
@@ -368,7 +368,7 @@ test.describe("single verification grid", () => {
       await fixture.makeDecision(0);
       await fixture.page.waitForTimeout(1000);
 
-      const expectedTooltip = "3 / 30 (10%) audio segments completed";
+      const expectedTooltip = "3 / 30 (10.00%) audio segments completed";
       const completedTooltips = await fixture.gridProgressBarCompletedTooltip().count();
       const realizedViewHeadTooltip = await fixture.progressBarViewHeadTooltip();
 
@@ -390,7 +390,7 @@ test.describe("single verification grid", () => {
       await fixture.makeDecision(0);
       await fixture.viewPreviousHistoryPage();
 
-      const expectedCompletedTooltip = "3 / 30 (10%) audio segments completed (viewing history)";
+      const expectedCompletedTooltip = "3 / 30 (10.00%) audio segments completed (viewing history)";
       const realizedCompletedTooltip = await fixture.progressBarCompletedTooltip();
 
       // because the user is at the start of the history, we should not have a

--- a/webcomponents.code-workspace
+++ b/webcomponents.code-workspace
@@ -65,6 +65,7 @@
       "samford",
       "subsite",
       "teleporting",
+      "progressbar",
     ],
     "cSpell.flagWords": ["yuo"],
     "cSpell.ignorePaths": ["**/node_modules/**", "**/dist/**", "webcomponents.code-workspace"],


### PR DESCRIPTION
# Add a progress bar to show dataset progress

A short description of the pull request

## Changes

### Features

- Add progress bar to verification grid to show how far through the dataset the user is
- Adds `aria-label` to classification component buttons (tested with screenreaders)

### Bug Fixes

- Moves the `1rem` `kbd` element height to the abstract decision component. This was done so that the fixed `kbd` element height is does not apply to the `kbd` element helpers shown during `Alt` + `#` selection or in the help dialog
- During Playwright tests, the spectrogram container used to grow indefinitely. This has now been correctly fixed meaning that tests are **much** less flakey, and easier to develop. It also fixes tests failing on the main branch

### Code Quality

None

### Remaining Bugs / Unresolved Problems

## Visual Changes

![image](https://github.com/user-attachments/assets/8faff7d5-5158-43a0-ad13-659a24429acb)

_A progress bar when **not** viewing history_

---

![image](https://github.com/user-attachments/assets/921b89d0-beeb-43a8-b82a-aa93e6bfcffb)

_A progress bar **when** viewing history_

In this image, I am viewing history, the darker region of the progress bar shows the current position of my view head (what is being shown on the screen). While the less shaded region shows where my verification head is up to.

Note: Tooltips always show how far through your verification head is

## Related Issues

Fixes: #163

## Additional Notes

## Final Checklist

- [x] All commits messages are semver compliant
- [x] Added relevant unit tests for new functionality
- [x] Updated existing unit tests to reflect changes
- [x] Code style is consistent with the project guidelines
- [ ] Documentation is updated to reflect the changes (if applicable)
- [x] Link issues related to the PR
- [x] Assign labels if you have permission
- [x] Assign reviewers if you have permission
- [ ] Ensure that CI is passing
- [x] Ensure that `pnpm lint` runs without any errors
- [x] Ensure that `pnpm test` runs without any errors
