### PR TITLE
Feat: Add the ability to transform subject urls

### DIFF
--- a/src/components/data-source/data-source.ts
+++ b/src/components/data-source/data-source.ts
@@ -10,8 +10,8 @@ import { Subject, SubjectWrapper } from "../../models/subject";
 import { DataSourceFetcher } from "../../services/dataSourceFetcher";
 import { PageFetcher } from "../../services/gridPageFetcher";
 import { VerificationGridComponent } from "../verification-grid/verification-grid";
-import dataSourceStyles from "./css/style.css?inline";
 import { required } from "../../helpers/decorators";
+import dataSourceStyles from "./css/style.css?inline";
 
 type PagingContext = {
   page: number;

--- a/src/components/verification-grid/verification-grid.ts
+++ b/src/components/verification-grid/verification-grid.ts
@@ -7,7 +7,7 @@ import { VerificationHelpDialogComponent } from "./help-dialog";
 import { callbackConverter } from "../../helpers/attributes";
 import { sleep } from "../../helpers/utilities";
 import { classMap } from "lit/directives/class-map.js";
-import { GridPageFetcher, PageFetcher } from "../../services/gridPageFetcher";
+import { GridPageFetcher, PageFetcher, UrlTransformer } from "../../services/gridPageFetcher";
 import { ESCAPE_KEY, LEFT_ARROW_KEY, RIGHT_ARROW_KEY } from "../../helpers/keyboard";
 import { SubjectWrapper } from "../../models/subject";
 import { ClassificationComponent } from "../decision/classification/classification";
@@ -132,6 +132,15 @@ export class VerificationGridComponent extends AbstractComponent(LitElement) {
   /** A callback function that returns a page of recordings */
   @property({ attribute: "get-page", type: Function, converter: callbackConverter as any })
   public getPage?: PageFetcher;
+
+  /**
+   * A callback function that will be applied to all subject urls
+   *
+   * @default
+   * an identity function that returns the url unchanged
+   */
+  @property({ attribute: "url-transformer", type: Function, converter: callbackConverter as any })
+  public urlTransformer: UrlTransformer = (url) => url;
 
   @state()
   private historyHead = 0;
@@ -310,7 +319,7 @@ export class VerificationGridComponent extends AbstractComponent(LitElement) {
     // increases, there will be verification grid tiles without any source
     // additionally, if the grid size is decreased, we want the "currentPage"
     // of sources to update / remove un-needed items
-    const sourceInvalidationKeys: (keyof this)[] = ["getPage", "targetGridSize", "columns", "rows"];
+    const sourceInvalidationKeys: (keyof this)[] = ["getPage", "urlTransformer", "targetGridSize", "columns", "rows"];
 
     // tile invalidations cause the functionality of the tiles to change
     // however, they do not cause the spectrograms or the template to render
@@ -374,7 +383,7 @@ export class VerificationGridComponent extends AbstractComponent(LitElement) {
     this.subjectHistory = [];
 
     if (this.getPage) {
-      this.paginationFetcher = new GridPageFetcher(this.getPage);
+      this.paginationFetcher = new GridPageFetcher(this.getPage, this.urlTransformer);
       this.currentPage = await this.paginationFetcher.getItems(this.populatedTileCount);
     }
   }

--- a/src/helpers/attributes.ts
+++ b/src/helpers/attributes.ts
@@ -43,6 +43,10 @@ export const tagConverter = (value: string | null): Tag => {
  */
 export const callbackConverter = (value: string | ((...params: any) => any)) => {
   if (typeof value === "string") {
+    if (value === "") {
+      throw new Error("Empty string is not a valid callback");
+    }
+
     return new Function(value);
   }
 

--- a/src/services/gridPageFetcher.ts
+++ b/src/services/gridPageFetcher.ts
@@ -105,7 +105,8 @@ export class GridPageFetcher {
     const { subjects, context, totalItems } = await this.pagingCallback(this.pagingContext);
     const models = subjects.map(this.converter.parse);
 
-    // TODO: this is a hack that was implemented so that we can use
+    // TODO: remove this hack that was implemented so that we can add
+    // authentication url parameters
     models.forEach((model) => {
       model.url = this.urlTransformer(model.url);
     });


### PR DESCRIPTION
# Feat: Add the ability to transform subject urls

## Changes

### Features

- Adds the ability to provide a `urlTransformer` to the verification grid that will be run over every subject URL. This is useful for URL parameter based authentication, and improved caching through file hashes

## Related Issues

Fixes: #208

## Final Checklist

- [x] All commits messages are semver compliant
- [ ] Added relevant unit tests for new functionality
- [ ] Updated existing unit tests to reflect changes
- [x] Code style is consistent with the project guidelines
- [ ] Documentation is updated to reflect the changes (if applicable)
- [x] Link issues related to the PR
- [x] Assign labels if you have permission
- [x] Assign reviewers if you have permission
- [ ] Ensure that CI is passing
- [x] Ensure that `pnpm lint` runs without any errors
- [x] Ensure that `pnpm test` runs without any errors
