### PR TITLE
CI: Allow manual trigger to run website publishing

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -6,6 +6,13 @@ on:
       production:
         required: true
         type: boolean
+  workflow_dispatch:
+    inputs:
+      production:
+        type: boolean
+        description: "Deploy to production website"
+        required: true
+        
 
 jobs:
   Documentation-Publish:


### PR DESCRIPTION
# CI: Allow manual trigger to run website publishing

Because our documentation website is published through the release workflow, we could previously not publish a version of the documentation website without also publishing a web components release.

This commit allows us to manually run the documentation publish workflow, allowing us to publish the documentation website without publishing a new version of the web components to npm.

Because we did not release a web components version with the goshawk verification deployment, the goshawk verification interface was never deployed to production.

## Changes

- Allows manually triggering the website publishing workflow. Allowing us to publish the website while not publishing a new web components version

## Final Checklist

- [ ] All commits messages are semver compliant
- [ ] Added relevant unit tests for new functionality
- [ ] Updated existing unit tests to reflect changes
- [ ] Code style is consistent with the project guidelines
- [ ] Documentation is updated to reflect the changes (if applicable)
- [ ] Link issues related to the PR
- [ ] Assign labels if you have permission
- [ ] Assign reviewers if you have permission
- [ ] Ensure that CI is passing
- [ ] Ensure that `pnpm lint` runs without any errors
- [ ] Ensure that `pnpm test` runs without any errors
