### PR TITLE
Fix: Reduce focus area for keyboard shortcuts

### DIFF
--- a/dev/verification-grid.html
+++ b/dev/verification-grid.html
@@ -38,6 +38,30 @@
     <button onclick="changeSelectionBehavior();">Change selection behavior</button>
     <button onclick="changeCallback();">Use custom callback</button>
 
+    <div class="host-application-tester">
+      <p>
+        This input box is outside of the verification grid. You should be able to type in it using decision shortcut
+        keys without the verification grid capturing it as a decision input.
+      </p>
+
+      <p>Hint: Try to use <kbd>Ctrl</kbd> + <kbd>A</kbd>. You should not see the verification grid get selected.</p>
+
+      <input type="text" />
+    </div>
+
+    <style>
+      .host-application-tester {
+        border: var(--oe-border-width) solid var(--oe-border-color);
+        border-radius: var(--oe-border-rounding);
+        padding: var(--oe-spacing);
+        margin-top: var(--oe-spacing);
+
+        &:has(:focus) {
+          background-color: var(--oe-selected-color);
+        }
+      }
+    </style>
+
     <script>
       const verificationGridElement = document.getElementById("verification-grid");
 

--- a/src/components/decision/classification/classification.fixture.ts
+++ b/src/components/decision/classification/classification.fixture.ts
@@ -22,6 +22,15 @@ class ClassificationComponentFixture {
     await this.page.setContent("<oe-classification tag='koala'></oe-classification>");
     await this.page.waitForLoadState("networkidle");
     await this.page.waitForSelector("oe-classification");
+
+    // mock the verification grid by binding it to the document object
+    // this means that we can test that the shortcut keys work correctly without
+    // having to create the entire verification grid
+    // shortcut keys + integration testing is tested in the verification grid
+    // e2e tests
+    await this.component().evaluate((element: ClassificationComponent) => {
+      element.verificationGrid = document as any;
+    });
   }
 
   public decisionEvent() {

--- a/src/components/decision/verification/verification.fixture.ts
+++ b/src/components/decision/verification/verification.fixture.ts
@@ -20,6 +20,15 @@ class VerificationComponentFixture {
     await this.page.setContent(`<oe-verification verified="true"></oe-verification>`);
     await this.page.waitForLoadState("networkidle");
     await this.page.waitForSelector("oe-verification");
+
+    // mock the verification grid by binding it to the document object
+    // this means that we can test that the shortcut keys work correctly without
+    // having to create the entire verification grid
+    // shortcut keys + integration testing is tested in the verification grid
+    // e2e tests
+    await this.component().evaluate((element: VerificationComponent) => {
+      element.verificationGrid = document as any;
+    });
   }
 
   // events

--- a/src/components/media-controls/media-controls.ts
+++ b/src/components/media-controls/media-controls.ts
@@ -144,6 +144,17 @@ export class MediaControlsComponent extends AbstractComponent(LitElement) {
   }
 
   private handleKeyDown(event: KeyboardEvent): void {
+    const ignoreTargets = ["input"];
+    const eventTarget = event.target;
+    if (!(eventTarget instanceof HTMLElement)) {
+      return;
+    }
+
+    const targetTag = eventTarget.tagName.toLowerCase();
+    if (ignoreTargets.includes(targetTag)) {
+      return;
+    }
+
     if (event.key === SPACE_KEY) {
       this.toggleAudio(true);
     }

--- a/src/components/verification-grid-tile/verification-grid-tile.ts
+++ b/src/components/verification-grid-tile/verification-grid-tile.ts
@@ -5,7 +5,7 @@ import { IPlayEvent, SpectrogramComponent } from "../spectrogram/spectrogram";
 import { classMap } from "lit/directives/class-map.js";
 import { consume, createContext, provide } from "@lit/context";
 import { booleanConverter } from "../../helpers/attributes";
-import { ENTER_KEY, SPACE_KEY } from "../../helpers/keyboard";
+import { ENTER_KEY } from "../../helpers/keyboard";
 import { decisionColors } from "../../helpers/themes/decisionColors";
 import { SubjectWrapper } from "../../models/subject";
 import { Decision, DecisionOptions } from "../../models/decisions/decision";
@@ -250,13 +250,6 @@ export class VerificationGridTileComponent extends SignalWatcher(AbstractCompone
   // in MacOS when the command key is held down
   // https://stackoverflow.com/q/11818637
   private handleKeyDown(event: KeyboardEvent): void {
-    // most browsers scroll a page width when the user presses the space bar
-    // however, since space bar can also be used to play spectrograms, we don't
-    // want to scroll when the space bar is pressed
-    if (event.key === SPACE_KEY) {
-      event.preventDefault();
-    }
-
     if (event.altKey && this.shortcuts.includes(event.key.toLowerCase())) {
       this.dispatchEvent(
         new CustomEvent(VerificationGridTileComponent.selectedEventName, {

--- a/src/components/verification-grid/verification-grid.ts
+++ b/src/components/verification-grid/verification-grid.ts
@@ -8,7 +8,7 @@ import { callbackConverter } from "../../helpers/attributes";
 import { sleep } from "../../helpers/utilities";
 import { classMap } from "lit/directives/class-map.js";
 import { GridPageFetcher, PageFetcher, UrlTransformer } from "../../services/gridPageFetcher";
-import { ESCAPE_KEY, LEFT_ARROW_KEY, RIGHT_ARROW_KEY } from "../../helpers/keyboard";
+import { ESCAPE_KEY, LEFT_ARROW_KEY, RIGHT_ARROW_KEY, SPACE_KEY } from "../../helpers/keyboard";
 import { SubjectWrapper } from "../../models/subject";
 import { ClassificationComponent } from "../decision/classification/classification";
 import { VerificationComponent } from "../decision/verification/verification";
@@ -243,14 +243,14 @@ export class VerificationGridComponent extends AbstractComponent(LitElement) {
 
   public connectedCallback(): void {
     super.connectedCallback();
-    document.addEventListener("keydown", this.keydownHandler);
-    document.addEventListener("keyup", this.keyupHandler);
+    this.addEventListener("keydown", this.keydownHandler);
+    this.addEventListener("keyup", this.keyupHandler);
     window.addEventListener("blur", this.blurHandler);
   }
 
   public disconnectedCallback(): void {
-    document.removeEventListener("keydown", this.keydownHandler);
-    document.removeEventListener("keyup", this.keyupHandler);
+    this.removeEventListener("keydown", this.keydownHandler);
+    this.removeEventListener("keyup", this.keyupHandler);
     window.removeEventListener("blur", this.blurHandler);
 
     this.gridContainer.removeEventListener<any>("selected", this.selectionHandler);
@@ -408,10 +408,23 @@ export class VerificationGridComponent extends AbstractComponent(LitElement) {
     this.injector.colorService = decisionColor;
   }
 
+  private updateDecisionElements(): void {
+    for (const element of this.decisionElements) {
+      element.verificationGrid = this;
+    }
+  }
+
   //#endregion
 
   //#region EventHandlers
   private handleKeyDown(event: KeyboardEvent): void {
+    // most browsers scroll a page width when the user presses the space bar
+    // however, since space bar can also be used to play spectrograms, we don't
+    // want to scroll when the space bar is pressed
+    if (event.key === SPACE_KEY) {
+      event.preventDefault();
+    }
+
     if (event.altKey) {
       // showing/hiding selection shortcuts is quite expensive because it
       // requires DOM queries
@@ -526,6 +539,7 @@ export class VerificationGridComponent extends AbstractComponent(LitElement) {
   private handleSlotChange(): void {
     this.updateRequiredClassificationTags();
     this.updateInjector();
+    this.updateDecisionElements();
   }
 
   private handleTileOverlap(event: OverflowEvent): void {

--- a/src/tests/verification-grid/verification-grid.e2e.fixture.ts
+++ b/src/tests/verification-grid/verification-grid.e2e.fixture.ts
@@ -40,6 +40,8 @@ import { SlTooltip } from "@shoelace-style/shoelace";
 class TestPage {
   public constructor(public readonly page: Page) {}
 
+  public hostAppInput = () => this.page.getByTestId("host-app-input").first();
+
   public gridComponent = () => this.page.locator("oe-verification-grid").first();
   public gridContainer = () => this.page.locator("#grid-container").first();
   public dataSourceComponent = () => this.page.locator("oe-data-source").first();
@@ -118,6 +120,33 @@ class TestPage {
     `);
     await this.page.waitForLoadState("networkidle");
     await this.page.waitForSelector("oe-verification-grid");
+  }
+
+  public async createWithAppChrome() {
+    await this.page.setContent(`
+      <div id="host-application-wrapper">
+        <oe-verification-grid id="verification-grid">
+          ${this.defaultTemplate}
+
+          <oe-data-source
+            slot="data-source"
+            for="verification-grid"
+            src="${this.testJsonInput}"
+          ></oe-data-source>
+        </oe-verification-grid>
+      </div>
+
+      <div>
+        <p>This is some content from the host application</p>
+
+        <p>
+          If you use this input box, you shouldn't trigger any key events on the
+          verification grid.
+        </p>
+
+        <input data-testid="host-app-input" type="text" />
+      </div>
+    `);
   }
 
   // getters

--- a/webcomponents.code-workspace
+++ b/webcomponents.code-workspace
@@ -67,6 +67,7 @@
       "teleporting",
       "progressbar",
       "pageerror",
+      "spacebar",
     ],
     "cSpell.flagWords": ["yuo"],
     "cSpell.ignorePaths": ["**/node_modules/**", "**/dist/**", "webcomponents.code-workspace"],


### PR DESCRIPTION
# Fix: Reduce focus area for keyboard shortcuts

Fixes keyboard shortcuts being bound at the document level.

This resolves bugs where if the web components were embedded into a host application with an input box, typing in the input box could trigger decision events via shortcut keys.

## Changes

- Reassign document-level event listeners for actioned shortcut keys to verification grid
	- Decision button shortcuts now listen for keyboard events on the verification grid component
	- Media controls "space to play" now listens for keyboard events on the verification grid component
- Space to play now checks if the event originated from within an `input` element. Meaning that if the user places an `input` component inside the grid tile slot, it will not trigger a play event when typing inside the input box
- Preventing "space to scroll" is now the responsability of the verification grid component (instead of each grid tile having an event listener at the document level to prevent default)
- Add associated tests

## Related Issues

Fixes: #91

## Final Checklist

- [ ] All commits messages are semver compliant
- [x] Added relevant unit tests for new functionality
- [x] Updated existing unit tests to reflect changes
- [x] Code style is consistent with the project guidelines
- [ ] Documentation is updated to reflect the changes (if applicable)
- [x] Link issues related to the PR
- [x] Assign labels if you have permission
- [x] Assign reviewers if you have permission
- [x] Ensure that CI is passing
- [x] Ensure that `pnpm lint` runs without any errors
- [x] Ensure that `pnpm test` runs without any errors
