### PR TITLE
feat(build): Emit ESM modules in build output

### DIFF
--- a/dev/cdn.html
+++ b/dev/cdn.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Web Components - CDN Test</title>
+    <!-- <script type="module" src="https://esm.run/@ecoacoustics/web-components/dist/components.js"></script> -->
+
+    <!-- Does not work because it tries to import the buffer-builder-processor incorrectly -->
+    <script type="module" src="https://esm.run/@ecoacoustics/web-components"></script>
+  </head>
+
+  <body>
+    <oe-verification-grid id="verification-grid">
+      <oe-verification verified="true" shortcut="Y"></oe-verification>
+      <oe-verification verified="false" shortcut="N"></oe-verification>
+
+      <oe-data-source slot="data-source" for="verification-grid" src="/grid-items.json" local></oe-data-source>
+    </oe-verification-grid>
+
+    <p>
+      This dev page tests the CDN. It will fetch the latest version of the web components from JSDelivr and create a
+      verification grid.
+    </p>
+
+    <section>
+      <h3>Warning</h3>
+      <p>
+          This page does not use a local development build. Make sure that the version that you are testing is published
+          to NPM.
+      </p>
+    </section>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
     <a href="/dev/verification-grid-callback.html">Verification Grid Callback</a>
 
     <a href="/dev/theme/theme.html">Theme Creator</a>
+    <a href="/dev/cdn.html">CDN</a>
     <a href="/dist/docs/index.html">Docs</a>
 
     <div class="use-case-demo-container">

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.1.5",
   "types": "@types/",
   "type": "module",
-  "main": "components.js",
+  "main": "./dist/components.js",
   "scripts": {
     "dev": "vite --host 0.0.0.0",
     "build": "build:components && build:docs",
@@ -21,25 +21,30 @@
     "format": "prettier . --write"
   },
   "files": [
-    "components.js",
-    "assets",
-    "@types"
+    "./dist/components.js",
+    "./dist/assets",
+    "./dist/@types"
   ],
   "exports": {
     ".": {
       "import": [
-        "./components.js",
-        "./assets/*",
+        "./dist/components.js",
+        "./dist/assets/*",
         "./@types/*"
       ],
       "require": [
-        "./components.js",
-        "./assets/*",
+        "./dist/components.js",
+        "./dist/assets/*",
         "./@types/*"
       ]
+    },
+    "./dist/components/*": {
+      "import": "./dist/components/*.js",
+      "require": "./dist/components/*.js",
+      "types": "./@types/components/*.d.ts"
     }
   },
-  "customElements": "custom-elements.json",
+  "customElements": "dist/custom-elements.json",
   "dependencies": {
     "@json2csv/plainjs": "^7.0.6",
     "@lit-labs/preact-signals": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ecoacoustics/web-components",
   "description": "Ecoacoustic web components",
-  "version": "1.1.6-alpha.2",
+  "version": "1.1.5",
   "types": "@types/",
   "type": "module",
   "main": "./dist/components.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ecoacoustics/web-components",
   "description": "Ecoacoustic web components",
-  "version": "1.1.6-alpha.1",
+  "version": "1.1.6-alpha.2",
   "types": "@types/",
   "type": "module",
   "main": "./dist/components.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ecoacoustics/web-components",
   "description": "Ecoacoustic web components",
-  "version": "1.1.5",
+  "version": "1.1.6-alpha.1",
   "types": "@types/",
   "type": "module",
   "main": "./dist/components.js",
@@ -21,28 +21,12 @@
     "format": "prettier . --write"
   },
   "files": [
-    "./dist/components.js",
-    "./dist/assets",
-    "./dist/@types"
+    "./dist",
+    "./@types"
   ],
   "exports": {
-    ".": {
-      "import": [
-        "./dist/components.js",
-        "./dist/assets/*",
-        "./@types/*"
-      ],
-      "require": [
-        "./dist/components.js",
-        "./dist/assets/*",
-        "./@types/*"
-      ]
-    },
-    "./dist/components/*": {
-      "import": "./dist/components/*.js",
-      "require": "./dist/components/*.js",
-      "types": "./@types/components/*.d.ts"
-    }
+    ".": "./dist/components.js",
+    "./dist/components/*": "./dist/components/*.js"
   },
   "customElements": "dist/custom-elements.json",
   "dependencies": {

--- a/src/components/decision/decision.ts
+++ b/src/components/decision/decision.ts
@@ -5,17 +5,13 @@ import { ESCAPE_KEY } from "../../helpers/keyboard";
 import { decisionColors } from "../../helpers/themes/decisionColors";
 import { AbstractComponent } from "../../mixins/abstractComponent";
 import { Decision } from "../../models/decisions/decision";
-import {
-  injectionContext,
-  SelectionObserverType,
-  VerificationGridComponent,
-  VerificationGridInjector,
-} from "../verification-grid/verification-grid";
+import { SelectionObserverType, VerificationGridComponent, VerificationGridInjector } from "../verification-grid/verification-grid";
 import { ClassificationComponent } from "./classification/classification";
 import { VerificationComponent } from "./verification/verification";
 import { consume } from "@lit/context";
 import { decisionColor } from "../../services/colors";
 import { KeyboardShortcut } from "verification-grid/help-dialog";
+import { injectionContext } from "../../helpers/constants/contextTokens";
 import decisionStyles from "./css/style.css?inline";
 
 interface DecisionContent {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -21,6 +21,8 @@ export * from "./decision/verification/verification";
 export * from "./verification-grid-settings/verification-grid-settings";
 export * from "./progress-bar/progress-bar";
 
+export * from "../helpers/constants/contextTokens";
+
 // TODO: cherry pick shoelace components
 // see: https://github.com/ecoacoustics/web-components/issues/83
 // import "@shoelace-style/shoelace/dist/components/menu/menu.js";

--- a/src/components/info-card/info-card.ts
+++ b/src/components/info-card/info-card.ts
@@ -1,10 +1,10 @@
 import { customElement, property, state } from "lit/decorators.js";
 import { AbstractComponent } from "../../mixins/abstractComponent";
 import { html, LitElement, nothing, TemplateResult, unsafeCSS } from "lit";
-import infoCardStyle from "./css/style.css?inline";
 import { consume } from "@lit/context";
-import { gridTileContext } from "../verification-grid-tile/verification-grid-tile";
 import { Subject, SubjectWrapper } from "../../models/subject";
+import { gridTileContext } from "../../helpers/constants/contextTokens";
+import infoCardStyle from "./css/style.css?inline";
 
 type InfoCardTemplate = (value: any) => any;
 

--- a/src/components/logger/logger.ts
+++ b/src/components/logger/logger.ts
@@ -1,17 +1,12 @@
-import { consume, createContext } from "@lit/context";
+import { consume } from "@lit/context";
 import { LitElement } from "lit";
 import { property } from "lit/decorators.js";
-
-export interface ILogger {
-  log: (message: string) => void;
-}
-
-export const rootContext = createContext<ILogger>(Symbol("rootContext"));
+import { IRootContext, rootContext } from "../../helpers/constants/contextTokens";
 
 export class LoggerImplementation extends LitElement {
   @consume({ context: rootContext, subscribe: true })
   @property({ attribute: false })
-  public logger?: ILogger;
+  public logger?: IRootContext;
 
   protected doThing(): void {
     this.logger?.log("Hello, world!");

--- a/src/components/media-controls/media-controls.ts
+++ b/src/components/media-controls/media-controls.ts
@@ -1,6 +1,5 @@
 import { LitElement, PropertyValues, TemplateResult, html, nothing, unsafeCSS } from "lit";
 import { customElement, property } from "lit/decorators.js";
-import { ILogger, rootContext } from "../logger/logger";
 import { provide } from "@lit/context";
 import { AbstractComponent } from "../../mixins/abstractComponent";
 import { SpectrogramComponent } from "../spectrogram/spectrogram";
@@ -10,6 +9,7 @@ import { AxesComponent } from "../axes/axes";
 import { windowFunctions } from "../../helpers/audio/window";
 import { colorScales } from "../../helpers/audio/colors";
 import { SPACE_KEY } from "../../helpers/keyboard";
+import { IRootContext, rootContext } from "../../helpers/constants/contextTokens";
 import mediaControlsStyles from "./css/style.css?inline";
 
 /**
@@ -63,7 +63,7 @@ export class MediaControlsComponent extends AbstractComponent(LitElement) {
   public playIconPosition: PreferenceLocation = "default";
 
   @provide({ context: rootContext })
-  private logger: ILogger = {
+  private logger: IRootContext = {
     log: console.log,
   };
 

--- a/src/components/spectrogram/spectrogram.ts
+++ b/src/components/spectrogram/spectrogram.ts
@@ -183,7 +183,15 @@ export class SpectrogramComponent extends SignalWatcher(AbstractComponent(LitEle
 
   // todo: this should be part of a mixin
   public disconnectedCallback(): void {
-    OeResizeObserver.instance.unobserve(this.canvas);
+    // if the spectrogram component is rapidly added and removed from the DOM
+    // the canvas will not be initialized, and the canvas can be undefined
+    // this can sometimes occur during tests if the test runner doesn't
+    // correctly wait for the component to be fully initialized
+    if (this.canvas instanceof Element) {
+      OeResizeObserver.instance.unobserve(this.canvas);
+    } else {
+      console.warn("Spectrogram component disconnected before canvas was initialized");
+    }
 
     // because the resize observer is disconnected when the spectrogram is
     // removed from the DOM, the unit converter value will still have the old

--- a/src/components/spectrogram/spectrogram.ts
+++ b/src/components/spectrogram/spectrogram.ts
@@ -187,11 +187,7 @@ export class SpectrogramComponent extends SignalWatcher(AbstractComponent(LitEle
     // the canvas will not be initialized, and the canvas can be undefined
     // this can sometimes occur during tests if the test runner doesn't
     // correctly wait for the component to be fully initialized
-    if (this.canvas instanceof Element) {
-      OeResizeObserver.instance.unobserve(this.canvas);
-    } else {
-      console.warn("Spectrogram component disconnected before canvas was initialized");
-    }
+    OeResizeObserver.instance.unobserve(this.canvas);
 
     // because the resize observer is disconnected when the spectrogram is
     // removed from the DOM, the unit converter value will still have the old

--- a/src/components/verification-grid-settings/verification-grid-settings.ts
+++ b/src/components/verification-grid-settings/verification-grid-settings.ts
@@ -1,16 +1,13 @@
 import { customElement, state } from "lit/decorators.js";
 import { AbstractComponent } from "../../mixins/abstractComponent";
 import { html, LitElement, unsafeCSS } from "lit";
-import {
-  VerificationGridComponent,
-  verificationGridContext,
-  VerificationGridSettings,
-} from "../verification-grid/verification-grid";
+import { VerificationGridComponent, VerificationGridSettings } from "../verification-grid/verification-grid";
 import { queryParentElement } from "../../helpers/decorators";
 import { ChangeEvent } from "../../helpers/types/advancedTypes";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { consume } from "@lit/context";
 import { SignalWatcher } from "@lit-labs/preact-signals";
+import { verificationGridContext } from "../../helpers/constants/contextTokens";
 import settingComponentStyles from "./css/style.css?inline";
 
 @customElement("oe-verification-grid-settings")

--- a/src/components/verification-grid-tile/verification-grid-tile.ts
+++ b/src/components/verification-grid-tile/verification-grid-tile.ts
@@ -3,24 +3,20 @@ import { AbstractComponent } from "../../mixins/abstractComponent";
 import { html, LitElement, TemplateResult, unsafeCSS } from "lit";
 import { IPlayEvent, SpectrogramComponent } from "../spectrogram/spectrogram";
 import { classMap } from "lit/directives/class-map.js";
-import { consume, createContext, provide } from "@lit/context";
+import { consume, provide } from "@lit/context";
 import { booleanConverter } from "../../helpers/attributes";
 import { ENTER_KEY } from "../../helpers/keyboard";
 import { decisionColors } from "../../helpers/themes/decisionColors";
 import { SubjectWrapper } from "../../models/subject";
 import { Decision, DecisionOptions } from "../../models/decisions/decision";
 import { SignalWatcher, watch } from "@lit-labs/preact-signals";
-import {
-  injectionContext,
-  verificationGridContext,
-  VerificationGridInjector,
-  VerificationGridSettings,
-} from "../verification-grid/verification-grid";
+import { VerificationGridInjector, VerificationGridSettings } from "../verification-grid/verification-grid";
 import { when } from "lit/directives/when.js";
 import { Tag } from "../../models/tag";
 import { repeat } from "lit/directives/repeat.js";
 import { hasCtrlLikeModifier } from "../../helpers/userAgent";
 import { ifDefined } from "lit/directives/if-defined.js";
+import { gridTileContext, injectionContext, verificationGridContext } from "../../helpers/constants/contextTokens";
 import verificationGridTileStyles from "./css/style.css?inline";
 
 export type OverflowEvent = CustomEvent<OverflowEventDetail>;
@@ -42,8 +38,6 @@ const shortcutTranslation: Record<string, string> = {
   9: "(",
   0: ")",
 } as const;
-
-export const gridTileContext = createContext<SubjectWrapper>(Symbol("grid-tile-context"));
 
 /**
  * @description

--- a/src/components/verification-grid/verification-grid.ts
+++ b/src/components/verification-grid/verification-grid.ts
@@ -15,7 +15,7 @@ import { VerificationComponent } from "../decision/verification/verification";
 import { Decision } from "../../models/decisions/decision";
 import { Tag } from "../../models/tag";
 import { Verification } from "../../models/decisions/verification";
-import { createContext, provide } from "@lit/context";
+import { provide } from "@lit/context";
 import { signal, Signal } from "@lit-labs/preact-signals";
 import { queryDeeplyAssignedElement } from "../../helpers/decorators";
 import { repeat } from "lit/directives/repeat.js";
@@ -26,6 +26,7 @@ import { decisionColor } from "../../services/colors";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { DynamicGridSizeController, GridShape } from "../../helpers/controllers/dynamic-grid-sizes";
 import verificationGridStyles from "./css/style.css?inline";
+import { injectionContext, verificationGridContext } from "../../helpers/constants/contextTokens";
 
 export type SelectionObserverType = "desktop" | "tablet" | "default";
 
@@ -43,9 +44,6 @@ export interface MousePosition {
   x: number;
   y: number;
 }
-
-export const verificationGridContext = createContext<VerificationGridSettings>(Symbol("verification-grid-context"));
-export const injectionContext = createContext<VerificationGridInjector>(Symbol("injection-context"));
 
 type SelectionEvent = CustomEvent<{
   shiftKey: boolean;

--- a/src/helpers/constants/contextTokens.ts
+++ b/src/helpers/constants/contextTokens.ts
@@ -1,0 +1,13 @@
+import { createContext } from "@lit/context";
+import { SubjectWrapper } from "../../models/subject";
+import { VerificationGridInjector, VerificationGridSettings } from "verification-grid/verification-grid";
+
+export interface IRootContext {
+  log: (message: string) => void;
+}
+
+export const gridTileContext = createContext<SubjectWrapper>(Symbol("grid-tile-context"));
+export const rootContext = createContext<IRootContext>(Symbol("rootContext"));
+
+export const verificationGridContext = createContext<VerificationGridSettings>(Symbol("verification-grid-context"));
+export const injectionContext = createContext<VerificationGridInjector>(Symbol("injection-context"));

--- a/src/helpers/constants/contextTokens.ts
+++ b/src/helpers/constants/contextTokens.ts
@@ -1,3 +1,11 @@
+// we have split the context tokens into a separate file so that they can be
+// imported in esm and cjs modules without importing any other modules
+//
+// we used to have these context tokens bundled with their context providers
+// however, this would result in the some custom elements being defined when we
+// only imported the context tokens. This was because all immediately executable
+// code would be executed when the context token bundle was imported
+
 import { createContext } from "@lit/context";
 import { SubjectWrapper } from "../../models/subject";
 import { VerificationGridInjector, VerificationGridSettings } from "verification-grid/verification-grid";
@@ -6,8 +14,12 @@ export interface IRootContext {
   log: (message: string) => void;
 }
 
-export const gridTileContext = createContext<SubjectWrapper>(Symbol("grid-tile-context"));
-export const rootContext = createContext<IRootContext>(Symbol("rootContext"));
+// we use strings here instead of symbols so that users can use these contexts
+// across different bundles / dynamic imports
+// if the context tokens were symbols, they would have different references
+// across different bundles and dynamic imports
+export const gridTileContext = createContext<SubjectWrapper>("oe-grid-tile-context");
+export const rootContext = createContext<IRootContext>("oe-root-context");
 
-export const verificationGridContext = createContext<VerificationGridSettings>(Symbol("verification-grid-context"));
-export const injectionContext = createContext<VerificationGridInjector>(Symbol("injection-context"));
+export const verificationGridContext = createContext<VerificationGridSettings>("oe-verification-grid-context");
+export const injectionContext = createContext<VerificationGridInjector>("oe-injection-context");

--- a/src/helpers/resizeObserver.ts
+++ b/src/helpers/resizeObserver.ts
@@ -25,7 +25,16 @@ export class OeResizeObserver {
   }
 
   public static unobserve(element: HTMLElement): void {
-    this.instance.unobserve(element);
+    // I have had to add this condition to prevent race conditions in component
+    // destruction
+    // e.g. If a component is added, and then destroyed before a full life cycle
+    // has completed
+    if (element instanceof Element) {
+      this.instance.unobserve(element);
+    } else {
+      console.warn("Attempted to unobserve a non-element");
+    }
+
     this.callbacks.delete(element);
   }
 }

--- a/src/polyfills/userAgentData.ts
+++ b/src/polyfills/userAgentData.ts
@@ -13,9 +13,16 @@ function userAgentPolyfill(): NavigatorUAData {
   } as any;
 }
 
-// if we don't use defineProperty, on Chrome we get the error
-// Cannot set property userAgentData of #<Navigator> which has only a getter
-const polyfill = navigator["userAgentData"] ?? userAgentPolyfill();
-Object.defineProperty(navigator as any, "userAgentData", {
-  get: () => polyfill,
-});
+
+const userAgentDataKey = "userAgentData" as const;
+
+// if multiple components are imported from multiple entry point, we only want
+// to apply the polyfill once
+if (!(userAgentDataKey in navigator)) {
+    // if we don't use defineProperty, on Chrome we get the error
+    // Cannot set property userAgentData of #<Navigator> which has only a getter
+    const polyfill = userAgentPolyfill();
+    Object.defineProperty(navigator as any, userAgentDataKey, {
+        get: () => polyfill,
+    });
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -53,8 +53,12 @@ export default defineConfig({
     copyPublicDir: false,
     lib: {
       entry: {
+        // the components.js entry imports all components, helpers, and services
+        // in a single barrel file. This is typically the entrypoint for CDN's
         components: "./src/components/index.ts",
 
+        // each entry point represents a component, helper, or service that can
+        // be imported individually without importing all components
         "components/media-controls": "./src/components/media-controls/media-controls.ts",
         "components/spectrogram": "./src/components/spectrogram/spectrogram.ts",
         "components/indicator": "./src/components/indicator/indicator.ts",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,6 @@ import postcssNested from "postcss-nested";
 import autoprefixer from "autoprefixer";
 // import mkcert from "vite-plugin-mkcert";
 
-// vite config for the dev server and documentation
 export default defineConfig({
   // if we use the default "spa" app type, if a page is not found, the server
   // will return the index.html file. This is annoying for tests and dev
@@ -50,13 +49,30 @@ export default defineConfig({
     // https: true,
   },
   build: {
-    // TODO: this should not be the root directory
-    outDir: ".",
+    outDir: "./dist",
     copyPublicDir: false,
     lib: {
-      name: "components",
-      fileName: "components",
-      entry: "src/components/index.ts",
+      entry: {
+        components: "./src/components/index.ts",
+
+        "components/media-controls": "./src/components/media-controls/media-controls.ts",
+        "components/spectrogram": "./src/components/spectrogram/spectrogram.ts",
+        "components/indicator": "./src/components/indicator/indicator.ts",
+        "components/logger": "./src/components/logger/logger.ts",
+        "components/axes": "./src/components/axes/axes.ts",
+        "components/verification-grid": "./src/components/verification-grid/verification-grid.ts",
+        "components/verification-grid-tile": "./src/components/verification-grid-tile/verification-grid-tile.ts",
+        "components/info-card": "./src/components/info-card/info-card.ts",
+        "components/data-source": "./src/components/data-source/data-source.ts",
+        "components/help-dialog": "./src/components/verification-grid/help-dialog.ts",
+        "components/decision": "./src/components/decision/decision.ts",
+        "components/classification": "./src/components/decision/classification/classification.ts",
+        "components/verification": "./src/components/decision/verification/verification.ts",
+        "components/verification-grid-settings": "./src/components/verification-grid-settings/verification-grid-settings.ts",
+        "components/progress-bar": "./src/components/progress-bar/progress-bar.ts",
+
+        "components/helpers/constants/contextTokens": "./src/helpers/constants/contextTokens.ts",
+      },
       formats: ["es"],
     },
   },


### PR DESCRIPTION
# Emit ESM modules in build output

Adds the ability for users to import tree-shaken ESM modules in their third-party applications.

Usage: `import "@ecoacoustics/web-components/components/spectrogram`

## Changes

- Each web component now has its own JavaScript build target under `components/[name].js`
- Moves context tokens and other constants to a `constants.ts` file
- Changes published directory to `dist/`
- Fix a potential race condition in resize observers where they would attempt to disconnect even if the component never rendered (first lifecycle was not complete)
- Fix a bug where polyfills were not idempotent causing errors if the components were imported twice into the same page

## Related Issues

Fixes: #219

## Final Checklist

- [x] All commits messages are semver compliant
- [ ] Added relevant unit tests for new functionality
- [ ] Updated existing unit tests to reflect changes
- [x] Code style is consistent with the project guidelines
- [ ] Documentation is updated to reflect the changes (if applicable)
- [x] Link issues related to the PR
- [x] Assign labels if you have permission
- [ ] Assign reviewers if you have permission
- [ ] Ensure that CI is passing
- [ ] Ensure that `pnpm lint` runs without any errors
- [x] Ensure that `pnpm test` runs without any errors
