### PR TITLE
ci(dependencies): Cache lfs assets in checkout

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -12,16 +12,14 @@ on:
         type: boolean
         description: "Deploy to production website"
         required: true
-        
 
 jobs:
   Documentation-Publish:
     name: Deploy Preview on Netlify
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          lfs: true
+      - name: Checkout
+        uses: nschloe/action-cached-lfs-checkout@v1
 
       - name: Install pnpm
         uses: pnpm/action-setup@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,9 +6,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          lfs: true
+      - name: Checkout
+        uses: nschloe/action-cached-lfs-checkout@v1
 
       - uses: pnpm/action-setup@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,10 +17,9 @@ jobs:
     steps:
       # publish to NPM for each release created
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: nschloe/action-cached-lfs-checkout@v1
         with:
           ref: ${{ github.ref }}
-          lfs: true
 
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,13 +13,11 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-      - name: Checkout and Setup
-        uses: actions/checkout@v4
-        with:
-          # Playwright snapshot tests generate pngs that are uploaded via
-          # git lfs. We therefore have to use git lfs when cloning the repo
-          # for tests so that snapshot tests have a truth to asset against
-          lfs: true
+      # Playwright snapshot tests generate pngs that are uploaded via
+      # git lfs. We therefore have to use git lfs when cloning the repo
+      # for tests so that snapshot tests have a truth to asset against
+      - name: Checkout
+        uses: nschloe/action-cached-lfs-checkout@v1
 
       - name: Grant Audio Permissions (MacOS)
         if: matrix.os == 'macos-latest'


### PR DESCRIPTION
# ci(dependencies): Cache lfs assets in checkout

GitHub limits free lfs asset transfers to 1GB a month

However, because our workflows download a lot of assets, we quickly exceeded this limit

This PR replaces the default `actions/checkout@4` for the `nschloe/action-cached-lfs-checkout@v1` action that uses `actions/cache` under the hood to cache lfs assets.

This should help reduce our lfs asset transfers

## Changes

- Use `nschloe/action-cached-lfs-checkout@v1` for cached lfs asset checkout

## Related Issues

Fixes: #215

## Final Checklist

- [x] All commits messages are semver compliant
- [ ] Added relevant unit tests for new functionality
- [ ] Updated existing unit tests to reflect changes
- [x] Code style is consistent with the project guidelines
- [ ] Documentation is updated to reflect the changes (if applicable)
- [x] Link issues related to the PR
- [x] Assign labels if you have permission
- [x] Assign reviewers if you have permission
- [ ] Ensure that CI is passing
- [x] Ensure that `pnpm lint` runs without any errors
- [ ] Ensure that `pnpm test` runs without any errors
