### PR TITLE
fix(grid): Highlight selection after resizing grid

### DIFF
--- a/dev/verification-grid.html
+++ b/dev/verification-grid.html
@@ -8,6 +8,14 @@
   </head>
 
   <body>
+    <header>
+      <h1>This is a header</h1>
+      <p>
+        This header exists so that the verification grid is not flush with the top of the page. You should be able to
+        scroll and have the verification grid still function as expected.
+      </p>
+    </header>
+
     <oe-verification-grid id="verification-grid">
       <template>
         <div>

--- a/docs-src/_includes/layouts/deployment.11ty.js
+++ b/docs-src/_includes/layouts/deployment.11ty.js
@@ -7,7 +7,7 @@ export default function render({ content, title }) {
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>${title}</title>
-    <script type="module" src="/components.js"></script>
+    <script type="module" src="/dist/components.js"></script>
   </head>
   <body>
     <div id="main-wrapper">

--- a/docs-src/_includes/page.11ty.js
+++ b/docs-src/_includes/page.11ty.js
@@ -16,7 +16,7 @@ export default function (data) {
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600|Roboto+Mono">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism-okaidia.min.css">
-    <script type="module" src="/components.js"></script>
+    <script type="module" src="/dist/components.js"></script>
   </head>
   <body>
     ${header()}

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -5,7 +5,7 @@ export default function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy("docs-src/docs.css");
   eleventyConfig.addPassthroughCopy("public/");
   eleventyConfig.addPassthroughCopy("docs-src/public/");
-  eleventyConfig.addPassthroughCopy("components.js");
+  eleventyConfig.addPassthroughCopy("dist/");
   eleventyConfig.addPassthroughCopy("assets/");
 
   eleventyConfig.addPassthroughCopy("node_modules/prismjs/themes/prism-okaidia.min.css");

--- a/package.json
+++ b/package.json
@@ -78,5 +78,5 @@
       "liquidjs": "10.16.4"
     }
   },
-  "packageManager": "pnpm@9.1.1+sha256.9551e803dcb7a1839fdf5416153a844060c7bce013218ce823410532504ac10b"
+  "packageManager": "pnpm@9.12.3+sha256.24235772cc4ac82a62627cd47f834c72667a2ce87799a846ec4e8e555e2d4b8b"
 }

--- a/src/tests/verification-grid/verification-grid.e2e.fixture.ts
+++ b/src/tests/verification-grid/verification-grid.e2e.fixture.ts
@@ -123,7 +123,14 @@ class TestPage {
   }
 
   public async createWithAppChrome() {
+    // this test fixture has an app chrome with a header so that the grid is not
+    // flush with the top of the page
+    // this allows us to test how the verification grid interacts with scrolling
     await this.page.setContent(`
+      <header>
+        <h1>Host Application</h1>
+      </header>
+
       <div id="host-application-wrapper">
         <oe-verification-grid id="verification-grid">
           ${this.defaultTemplate}
@@ -612,6 +619,19 @@ class TestPage {
         element.style.visibility = "hidden";
       });
     }
+  }
+
+  public async highlightSelectAllTiles() {
+    const verificationGrid = this.gridComponent();
+    const bounding = await verificationGrid.boundingBox();
+    if (!bounding) {
+      throw new Error("Could not get the bounding box of the verification grid");
+    }
+
+    const start = { x: bounding.x, y: bounding.y };
+    const end = { x: bounding.x + bounding.width, y: bounding.y + bounding.height };
+
+    await this.createSelectionBox(start, end);
   }
 
   private async changeGridSetting(key: keyof VerificationGridSettings, value: boolean) {

--- a/src/tests/verification-grid/verification-grid.e2e.spec.ts
+++ b/src/tests/verification-grid/verification-grid.e2e.spec.ts
@@ -689,83 +689,6 @@ test.describe("single verification grid", () => {
         expect(realizedSelectedTiles).toEqual(subSelection);
       });
 
-      // there is a human tendency to move the mouse by a very small amount when
-      // clicking the primary mouse button
-      // to prevent this, there should be a minimum move amount until we start
-      // creating a selection box
-      // we start the selection slightly outside the tile so that the grid tile
-      // does not register the client event
-      test("should not create a selection box if the user drags a small px amount", async ({ fixture }) => {
-        const dragAmount: Pixel = 10;
-
-        const targetTile = (await fixture.gridTileComponents())[0];
-        const targetLocation = await targetTile.boundingBox();
-        if (!targetLocation) {
-          throw new Error("Could not get the bounding box of the target tile");
-        }
-
-        const selectionBoxSize = { width: dragAmount, height: dragAmount };
-        const start: MousePosition = { x: targetLocation.x - dragAmount / 2, y: targetLocation.y - dragAmount / 2 };
-        const end: MousePosition = {
-          x: targetLocation.x + selectionBoxSize.width,
-          y: targetLocation.y + selectionBoxSize.height,
-        };
-
-        await fixture.createSelectionBox(start, end);
-
-        const expectedSelectedTiles = [];
-        const realizedSelectedTiles = await fixture.selectedTileIndexes();
-        expect(realizedSelectedTiles).toEqual(expectedSelectedTiles);
-      });
-
-      test("should be able to select a tile using the selection box", async ({ fixture }) => {
-        const targetTile = (await fixture.gridTileComponents())[0];
-        const targetLocation = await targetTile.boundingBox();
-        if (!targetLocation) {
-          throw new Error("Could not get the bounding box of the target tile");
-        }
-
-        const selectionBoxSize = { width: 100, height: 100 };
-        const start: MousePosition = { x: targetLocation.x, y: targetLocation.y };
-        const end: MousePosition = {
-          x: targetLocation.x + selectionBoxSize.width,
-          y: targetLocation.y + selectionBoxSize.height,
-        };
-
-        await fixture.createSelectionBox(start, end);
-
-        const expectedSelectedTiles = [0];
-        const realizedSelectedTiles = await fixture.selectedTileIndexes();
-        expect(realizedSelectedTiles).toEqual(expectedSelectedTiles);
-      });
-
-      test("should be able to select multiple tiles using the selection box", async ({ fixture }) => {
-        const targetStartTile = (await fixture.gridTileComponents())[0];
-        const targetEndTile = (await fixture.gridTileComponents())[1];
-
-        const targetStartLocation = await targetStartTile.boundingBox();
-        if (!targetStartLocation) {
-          throw new Error("Could not get the bounding box of the start tile");
-        }
-
-        const targetEndLocation = await targetEndTile.boundingBox();
-        if (!targetEndLocation) {
-          throw new Error("Could not get the bounding box of the end tile");
-        }
-
-        const start: MousePosition = { x: targetStartLocation.x, y: targetStartLocation.y };
-        const end: MousePosition = {
-          x: targetEndLocation.x + targetEndLocation.width,
-          y: targetEndLocation.y + targetEndLocation.height,
-        };
-
-        await fixture.createSelectionBox(start, end);
-
-        const expectedSelectedTiles = [0, 1];
-        const realizedSelectedTiles = await fixture.selectedTileIndexes();
-        expect(realizedSelectedTiles).toEqual(expectedSelectedTiles);
-      });
-
       // if this test is failing, it might be because the selection box is
       // triggering when dragging the brightness range input
       test("should not select when using the media controls brightness range input", async ({ fixture }) => {
@@ -774,6 +697,148 @@ test.describe("single verification grid", () => {
 
         const selectedTiles = await fixture.selectedTileIndexes();
         expect(selectedTiles).toHaveLength(0);
+      });
+
+      test.describe("highlight box selection", () => {
+        // there is a human tendency to move the mouse by a very small amount when
+        // clicking the primary mouse button
+        // to prevent this, there should be a minimum move amount until we start
+        // creating a selection box
+        // we start the selection slightly outside the tile so that the grid tile
+        // does not register the client event
+        test("should not create a selection box if the user drags a small px amount", async ({ fixture }) => {
+          const dragAmount: Pixel = 10;
+
+          const targetTile = (await fixture.gridTileComponents())[0];
+          const targetLocation = await targetTile.boundingBox();
+          if (!targetLocation) {
+            throw new Error("Could not get the bounding box of the target tile");
+          }
+
+          const selectionBoxSize = { width: dragAmount, height: dragAmount };
+          const start: MousePosition = { x: targetLocation.x - dragAmount / 2, y: targetLocation.y - dragAmount / 2 };
+          const end: MousePosition = {
+            x: targetLocation.x + selectionBoxSize.width,
+            y: targetLocation.y + selectionBoxSize.height,
+          };
+
+          await fixture.createSelectionBox(start, end);
+
+          const expectedSelectedTiles = [];
+          const realizedSelectedTiles = await fixture.selectedTileIndexes();
+          expect(realizedSelectedTiles).toEqual(expectedSelectedTiles);
+        });
+
+        test("should be able to select a tile", async ({ fixture }) => {
+          const targetTile = (await fixture.gridTileComponents())[0];
+          const targetLocation = await targetTile.boundingBox();
+          if (!targetLocation) {
+            throw new Error("Could not get the bounding box of the target tile");
+          }
+
+          const selectionBoxSize = { width: 100, height: 100 };
+          const start: MousePosition = { x: targetLocation.x, y: targetLocation.y };
+          const end: MousePosition = {
+            x: targetLocation.x + selectionBoxSize.width,
+            y: targetLocation.y + selectionBoxSize.height,
+          };
+
+          await fixture.createSelectionBox(start, end);
+
+          const expectedSelectedTiles = [0];
+          const realizedSelectedTiles = await fixture.selectedTileIndexes();
+          expect(realizedSelectedTiles).toEqual(expectedSelectedTiles);
+        });
+
+        test("should be able to select multiple tiles", async ({ fixture }) => {
+          const targetStartTile = (await fixture.gridTileComponents())[0];
+          const targetEndTile = (await fixture.gridTileComponents())[1];
+
+          const targetStartLocation = await targetStartTile.boundingBox();
+          if (!targetStartLocation) {
+            throw new Error("Could not get the bounding box of the start tile");
+          }
+
+          const targetEndLocation = await targetEndTile.boundingBox();
+          if (!targetEndLocation) {
+            throw new Error("Could not get the bounding box of the end tile");
+          }
+
+          const start: MousePosition = { x: targetStartLocation.x, y: targetStartLocation.y };
+          const end: MousePosition = {
+            x: targetEndLocation.x + targetEndLocation.width,
+            y: targetEndLocation.y + targetEndLocation.height,
+          };
+
+          await fixture.createSelectionBox(start, end);
+
+          const expectedSelectedTiles = [0, 1];
+          const realizedSelectedTiles = await fixture.selectedTileIndexes();
+          expect(realizedSelectedTiles).toEqual(expectedSelectedTiles);
+        });
+
+        test("should not be able to sub-select for a grid size of one", async ({ fixture }) => {
+          await fixture.changeGridSize(1);
+          await fixture.highlightSelectAllTiles();
+
+          const selectedTiles = await fixture.selectedTiles();
+          expect(selectedTiles).toHaveLength(0);
+        });
+
+        test("should be able to select new tiles if the grid size increases", async ({ fixture }) => {
+          const currentGridSize = await fixture.getGridSize();
+          await fixture.changeGridSize(currentGridSize + 1);
+
+          await fixture.highlightSelectAllTiles();
+
+          const expectedNumberOfSelected = await fixture.getGridSize();
+          const realizedSelectedTiles = await fixture.selectedTiles();
+          expect(realizedSelectedTiles).toHaveLength(expectedNumberOfSelected);
+        });
+
+        // if old tiles that no longer exist are still being selected this test will fail
+        test("should select the correct number of tiles if the grid size decreases", async ({ fixture }) => {
+          const currentGridSize = await fixture.getGridSize();
+          const newGridSize = Math.min(1, currentGridSize);
+          await fixture.changeGridSize(newGridSize);
+
+          await fixture.highlightSelectAllTiles();
+
+          // if the user should not be able to sub-select (a grid size of one)
+          // then we should not see that any tiles are selected
+          const canSubSelect = newGridSize > 1;
+          const expectedNumberOfSelected = canSubSelect ? newGridSize : 0;
+          const realizedSelectedTiles = await fixture.selectedTiles();
+
+          expect(realizedSelectedTiles).toHaveLength(expectedNumberOfSelected);
+        });
+
+        test("should select tiles correctly after scrolling", async ({ fixture }) => {
+          await fixture.createWithAppChrome();
+          await fixture.dismissHelpDialog();
+
+          const scrollX: Pixel = 0;
+          const scrollY: Pixel = 100;
+          await fixture.page.mouse.wheel(scrollX, scrollY);
+
+          // we test selecting less than the amount that we have scrolled
+          // because it is the most likely region of the application to break
+          //
+          // we start selecting from the amount that we have scrolled because
+          // that will be the very top left of the screen
+          const selectionBoxSize: Pixel = 50;
+          const selectionBoxStart = { x: scrollX, y: scrollY };
+          const selectionBoxEnd = {
+            x: selectionBoxStart.x + selectionBoxSize,
+            y: selectionBoxStart.y + selectionBoxSize,
+          };
+
+          await fixture.createSelectionBox(selectionBoxStart, selectionBoxEnd);
+
+          const expectedSelectedTiles = [0];
+          const realizedSelectedTiles = await fixture.selectedTileIndexes();
+          expect(realizedSelectedTiles).toEqual(expectedSelectedTiles);
+        });
       });
     };
 


### PR DESCRIPTION
# fix(grid): Highlight selection after resizing grid

## Changes

- Fixes a bug where increasing the grid size would not cause new grid tiles to be highlightable
- Fixes a bug where non-zero offset verification grids would have misaligned highlight box intersection checks
- Fixes a bug where the highlight box would not disappear when changing mobile browser site settings from "desktop mode" to the default mobile mode when highlighting
- Fixes a bug where the selection highlight box would not recognise new grid tiles if they were added/removed while highlighting (typically occurred in dynamic grid size shrinking)
- Fix netlify site still using old build asset locations
- Use pointer events for highlight selection box
- Update pnpm corepack version

Fixes: #187

## Final Checklist

- [x] All commits messages are semver compliant
- [x] Added relevant unit tests for new functionality
- [x] Updated existing unit tests to reflect changes
- [x] Code style is consistent with the project guidelines
- [ ] Documentation is updated to reflect the changes (if applicable)
- [x] Link issues related to the PR
- [x] Assign labels if you have permission
- [x] Assign reviewers if you have permission
- [x] Ensure that CI is passing
- [x] Ensure that `pnpm lint` runs without any errors
- [x] Ensure that `pnpm test` runs without any errors
