### PR TITLE
docs: Add cane toads verification deployment

### DIFF
--- a/docs-src/deployments/cane-toads.md
+++ b/docs-src/deployments/cane-toads.md
@@ -1,0 +1,78 @@
+---
+layout: layouts/deployment.11ty.js
+title: Cane Toads Verification
+---
+
+<oe-verification-grid id="verification-grid">
+    <oe-verification verified="true" shortcut="Y"></oe-verification>
+    <oe-verification verified="false" shortcut="N"></oe-verification>
+    <oe-data-source id="data-source" slot="data-source" for="verification-grid" local></oe-data-source>
+</oe-verification-grid>
+
+<script>
+const helpMessage = `
+Please input your Ecosounds 'Authentication Token'.
+You can find your authentication token at the bottom left corner of ecosounds.org/my_account
+
+1. Go to ecosounds.org
+2. Click on "Log In" in the menu bar
+3. Log into your account using your email and password
+4. Click on your username in the top-right of the menu bar
+5. In the bottom left of your profile, you should see a card called 'Authentication Token'. Press the eye icon, then copy the text
+6. Paste the text into this prompt and press 'Ok'
+`;
+let doneDecision = false;
+
+function createUrlTransformer(authToken) {
+    return (url, subject) => {
+      // sometimes this dataset will have a url field, sometimes it will not
+      // if it does we want to use the "url" column, if not, then we can
+      // automatically derive it from the other columns
+      const derivedUrl = !!url ? url : deriveUrlFromSubject(subject)
+      return `${derivedUrl}&user_token=${authToken}`;
+    }
+}
+
+function deriveUrlFromSubject(subject) {
+  const apiRoot = "https://api.ecosounds.org";
+
+  const audioRecordingId = subject.RecordingID;
+  const startOffset = subject.Start;
+  const endOffset = subject.End;
+
+  return `${apiRoot}/audio_recordings/${audioRecordingId}/media.flac` +
+         `?start_offset=${startOffset}&end_offset=${endOffset}`;
+}
+
+function setup() {
+    const verificationGrid = document.getElementById("verification-grid");
+    const dataSource = document.getElementById("data-source");
+    let authToken = undefined;
+
+    verificationGrid.addEventListener("decision", () => {
+        madeDecision = true;
+    });
+
+    // if the user doesn't put in an authentication token or presses cancel
+    // we want to keep showing them the auth token prompt
+    do {
+        authToken = prompt(helpMessage);
+    } while (!authToken)
+
+    // we use a url transformer to add the user_token parameter to all the
+    // subject urls
+    // this authentication token will NOT be added to the results output
+    verificationGrid.urlTransformer = createUrlTransformer(authToken);
+}
+
+window.addEventListener("load", () => {
+    setup();
+});
+
+window.addEventListener("beforeunload", (e) => {
+    if (madeDecision) {
+        e.preventDefault();
+        e.returnValue = "";
+    }
+});
+</script>

--- a/src/components/data-source/data-source.ts
+++ b/src/components/data-source/data-source.ts
@@ -214,7 +214,7 @@ export class DataSourceComponent extends AbstractComponent(LitElement) {
     }
 
     if (verification) {
-      verificationColumns[`${namespace}tag`] = decision.tag;
+      verificationColumns[`${namespace}tag`] = decision.tag.text;
       verificationColumns[`${namespace}confirmed`] = verification.confirmed;
     }
 
@@ -282,7 +282,7 @@ export class DataSourceComponent extends AbstractComponent(LitElement) {
           @click="${handleClick}"
           aria-controls="browser-file-input"
         >
-          ${this.fileName ? `File: ${this.fileName}` : "Browse files"}
+          ${this.fileName ? "Browse files" : "Browse files"}
         </button>
         <input
           id="browser-file-input"

--- a/src/services/gridPageFetcher.ts
+++ b/src/services/gridPageFetcher.ts
@@ -1,4 +1,4 @@
-import { SubjectWrapper } from "../models/subject";
+import { Subject, SubjectWrapper } from "../models/subject";
 import { SubjectParser } from "./subjectParser";
 
 export interface IPageFetcherResponse<T> {
@@ -11,7 +11,7 @@ export interface IPageFetcherResponse<T> {
  * A callback that will be applied to every subjects url
  * this can be useful for adding authentication information
  */
-export type UrlTransformer = (url: string) => string;
+export type UrlTransformer = (url: string, subject?: Subject) => string;
 
 /**
  * A context object that is passed to the page fetcher function after every call
@@ -21,7 +21,9 @@ export type UrlTransformer = (url: string) => string;
 export type PageFetcherContext = Record<string, unknown>;
 // TODO: remove the brand from the PageFetcher. This was done so that we could
 // see if the callback was created by the UrlSourcedFetcher
-export type PageFetcher<T extends PageFetcherContext = any> = ((context: T) => Promise<IPageFetcherResponse<T>>) & { brand?: symbol };
+export type PageFetcher<T extends PageFetcherContext = any> = ((context: T) => Promise<IPageFetcherResponse<T>>) & {
+  brand?: symbol;
+};
 
 export class GridPageFetcher {
   public constructor(pagingCallback: PageFetcher, urlTransformer: UrlTransformer) {
@@ -110,7 +112,7 @@ export class GridPageFetcher {
     // TODO: remove this hack that was implemented so that we can add
     // authentication url parameters
     models.forEach((model) => {
-      model.url = this.urlTransformer(model.url);
+      model.url = this.urlTransformer(model.url, model.subject);
     });
 
     this.totalItems = totalItems;

--- a/src/services/modelParser.ts
+++ b/src/services/modelParser.ts
@@ -34,7 +34,10 @@ export abstract class ModelParser<T> {
   }
 
   private static getKeyPermutations(key: string): string[] {
+    const identityCase = (value: any) => value;
+
     const supportedCasings = [
+      identityCase,
       camelCase,
       snakeCase,
       dotCase,

--- a/src/services/subjectParser.ts
+++ b/src/services/subjectParser.ts
@@ -30,6 +30,14 @@ export abstract class SubjectParser extends ModelParser<SubjectWrapper> {
         "scientificName",
         "commonName",
 
+        // for some reason, upper cased dot-case (e.g. Common.Name) isn't in our
+        // change-case library. To quick-fix this for a deployment, I have manually
+        // added a transformer for "Common.Name" to "commonName"
+        // This is a temporary fix and should be replaced with a proper
+        // implementation in the future.
+        // TODO: replace this with a proper implementation
+        "Common.Name",
+
         // Ecosounds annotation download formats
         "commonNameTags",
         "speciesNameTags",


### PR DESCRIPTION
# docs: Add cane toads verification deployment

## Changes

- Adds a cane-toads deployment to the docs website
- Adds quick and dirty hack to support parsing "Common.Name" fields
- Fixes a bug where the tag object would be emitted in verification result downloads (uplifed fix from #240)

## Visual changes

![image](https://github.com/user-attachments/assets/768cacb1-172c-4cd3-acce-231e818aa2e4)

_A popup prompting the validator to provide their authentication token (so they can access the private ecosounds project (FireFox)_

![image](https://github.com/user-attachments/assets/e2a651fc-69d1-4a68-81d6-3b70a595497b)

_A popup prompting the validator to provide their authentication token (so they can access the private ecosounds project (Chrome)_

![image](https://github.com/user-attachments/assets/f8983915-2ae2-4c34-9ad5-bbc9bfcdcafc)

_The cane-toads verification interface deployment (with redacted spectrograms & axes for data-privacy)_

## Unresolved issues

This PR opens up a new issue to propperly support "upper-case dot-cased" fields (e.g. "Common.Name")

## Final Checklist

- [x] All commits messages are semver compliant
- [ ] Added relevant unit tests for new functionality
- [ ] Updated existing unit tests to reflect changes
- [x] Code style is consistent with the project guidelines
- [ ] Documentation is updated to reflect the changes (if applicable)
- [x] Link issues related to the PR
- [x] Assign labels if you have permission
- [x] Assign reviewers if you have permission
- [x] Ensure that CI is passing
- [x] Ensure that `pnpm lint` runs without any errors
- [x] Ensure that `pnpm test` runs without any errors
