### PR TITLE
fix: support calling toJSON on downloaded subjects

### DIFF
--- a/dev/use-cases/ecosounds.html
+++ b/dev/use-cases/ecosounds.html
@@ -51,6 +51,11 @@
           const tag = randomSample(possibleTags);
 
           return {
+            injector: {
+              type: "audio",
+              provider: { src },
+              warning: "you should not see this value in the downloaded result"
+            },
             additionalData: {
               data: "This is some additional data that should be included in results",
               dateTime: new Date().toISOString(),
@@ -58,6 +63,12 @@
             additionalText: "you should see this in the results",
             src,
             tag,
+            toJSON: function() {
+              // return all properties in this object except for the 'injector'
+              // property
+              const { injector, ...subjectData } = this;
+              return subjectData;
+            },
           };
         });
 

--- a/src/models/subject.spec.ts
+++ b/src/models/subject.spec.ts
@@ -147,6 +147,20 @@ const tests: SubjectWrapperTest[] = [
     // modification when we download the results
     expectedDownloadableResult: fakeSubject as DownloadableResult,
   },
+  {
+    name: "complex object with toJSON method",
+    subject: {
+      fileName: "this value should not be emitted",
+      createdAt: 999,
+      updatedAt: 9999,
+      nestedObject: { name: "non-downloaded name field" },
+      toJSON: () => ({ x: "only x should be emitted" }),
+    },
+    tag: { text: "foo" },
+    expectedVerification: undefined,
+    expectedClassifications: [],
+    expectedDownloadableResult: { x: "only x should be emitted" },
+  },
   testVerificationDecision(),
   testClassificationDecision(),
   testMultipleClassificationDecisions(),

--- a/src/models/subject.ts
+++ b/src/models/subject.ts
@@ -161,8 +161,16 @@ export class SubjectWrapper {
       classificationColumns[column] = value;
     }
 
+    // the toJSON method is a protocol that is used by JSON.stringify and
+    // other serialization methods to convert an object into a more simplified
+    // format
+    // we test if the subject has a toJSON method and use it if possible
+    // since toJSON isn't always available on the object prototype, we want to
+    // simply return the original object if the toJSON method isn't available
+    const originalSubject = typeof this.subject.toJSON === "function" ? this.subject.toJSON() : this.subject;
+
     return {
-      ...this.subject,
+      ...originalSubject,
       ...verificationColumns,
       ...classificationColumns,
     };


### PR DESCRIPTION
# fix: support calling toJSON on downloaded subjects

## Changes

- The `SubjectWrapper`'s `toDownloadable` method now calls `toJSON` on the original subject when attempting to download results
- Updates the ecosounds page with an subject injector that should not be emitted by the `toJSON` result

## Final Checklist

- [x] All commits messages are semver compliant
- [x] Added relevant unit tests for new functionality
- [x] Updated existing unit tests to reflect changes
- [x] Code style is consistent with the project guidelines
- [ ] Documentation is updated to reflect the changes (if applicable)
- [ ] Link issues related to the PR
- [x] Assign labels if you have permission
- [ ] Assign reviewers if you have permission
- [ ] Ensure that CI is passing
- [x] Ensure that `pnpm lint` runs without any errors
- [ ] Ensure that `pnpm test` runs without any errors
