### PR TITLE
refactor: Unify view and history subject array

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,8 +2,5 @@
   "$schema": "https://json.schemastore.org/prettierrc",
   "trailingComma": "all",
   "semi": true,
-  "printWidth": 120,
-  "options": {
-    "editorconfig": true
-  }
+  "printWidth": 120
 }

--- a/dev/spectrogram.html
+++ b/dev/spectrogram.html
@@ -19,7 +19,7 @@
           contrast="2"
           scaling="stretch"
         >
-          <source src="/example2.flac"></source>
+          <source src="/example2.flac" />
         </oe-spectrogram>
       </oe-indicator>
     </oe-axes>

--- a/dev/use-cases/ecosounds.html
+++ b/dev/use-cases/ecosounds.html
@@ -45,6 +45,10 @@
 
       const possibleTags = ["bird", "insect", "mammal", "reptile"];
 
+      function createUrlTransformer() {
+        return (url) => `${url}?url_transformer=true`;
+      }
+
       function gridPaginator() {
         const subjects = Array.from({ length: 25 }).map(() => {
           const src = randomSample(possibleAudioSamples);
@@ -54,7 +58,7 @@
             injector: {
               type: "audio",
               provider: { src },
-              warning: "you should not see this value in the downloaded result"
+              warning: "you should not see this value in the downloaded result",
             },
             additionalData: {
               data: "This is some additional data that should be included in results",
@@ -63,7 +67,7 @@
             additionalText: "you should see this in the results",
             src,
             tag,
-            toJSON: function() {
+            toJSON: function () {
               // return all properties in this object except for the 'injector'
               // property
               const { injector, ...subjectData } = this;
@@ -77,6 +81,7 @@
 
       function setup() {
         const verificationGrid = document.querySelector("oe-verification-grid");
+        verificationGrid.urlTransformer = createUrlTransformer();
         verificationGrid.getPage = gridPaginator;
       }
 

--- a/docs-src/deployments/cane-toads.md
+++ b/docs-src/deployments/cane-toads.md
@@ -21,7 +21,7 @@ You can find your authentication token at the bottom left corner of ecosounds.or
 5. In the bottom left of your profile, you should see a card called 'Authentication Token'. Press the eye icon, then copy the text
 6. Paste the text into this prompt and press 'Ok'
 `;
-let doneDecision = false;
+let madeDecision = false;
 
 function createUrlTransformer(authToken) {
     return (url, subject) => {

--- a/docs-src/deployments/goshawk.md
+++ b/docs-src/deployments/goshawk.md
@@ -21,7 +21,7 @@ You can find your authentication token at the bottom left corner of ecosounds.or
 5. In the bottom left of your profile, you should see a card called 'Authentication Token'. Press the eye icon, then copy the text
 6. Paste the text into this prompt and press 'Ok'
 `;
-let doneDecision = false;
+let madeDecision = false;
 
 function createUrlTransformer(authToken) {
     return (url) => `${url}&user_token=${authToken}`;

--- a/src/components/axes/axes.fixture.ts
+++ b/src/components/axes/axes.fixture.ts
@@ -1,5 +1,6 @@
 import { Page } from "@playwright/test";
 import { test } from "../../tests/assertions";
+import { waitForContentReady } from "../../tests/helpers";
 
 class AxesFixture {
   public constructor(public readonly page: Page) {}
@@ -13,8 +14,7 @@ class AxesFixture {
         <div data-testid="inner-content"></div>
       </oe-axes>
     `);
-    await this.page.waitForLoadState("networkidle");
-    await this.page.waitForSelector("oe-axes");
+    await waitForContentReady(this.page, ["oe-axes"]);
   }
 }
 

--- a/src/components/data-source/data-source.fixture.ts
+++ b/src/components/data-source/data-source.fixture.ts
@@ -1,7 +1,7 @@
 import { Page } from "@playwright/test";
-import { removeBrowserAttribute, setBrowserAttribute } from "../../tests/helpers";
+import { removeBrowserAttribute, setBrowserAttribute, waitForContentReady } from "../../tests/helpers";
 import { DataSourceComponent } from "./data-source";
-import { Subject } from "../../models/subject";
+import { DownloadableResult, Subject } from "../../models/subject";
 import { test } from "../../tests/assertions";
 
 class DataSourceFixture {
@@ -41,9 +41,7 @@ class DataSourceFixture {
       </oe-verification-grid>
     `);
 
-    await this.page.waitForLoadState("networkidle");
-    await this.page.waitForSelector("oe-data-source");
-    await this.page.waitForSelector("oe-verification-grid");
+    await waitForContentReady(this.page, ["oe-verification-grid", "oe-data-source", "oe-verification"]);
   }
 
   public async setLocalAttribute(value: boolean) {
@@ -80,13 +78,13 @@ class DataSourceFixture {
   }
 
   public async getFileContent(): Promise<ReadonlyArray<Subject>> {
-    return (await this.component().evaluate(
-      (element: DataSourceComponent) => element.urlSourcedFetcher?.subjects() ?? [],
+    return (await this.component().evaluate((element: DataSourceComponent) =>
+      element.urlSourcedFetcher?.generateSubjects(),
     )) as ReadonlyArray<Subject>;
   }
 
-  public async getDownloadResults(): Promise<ReadonlyArray<Subject>> {
-    return await this.component().evaluate((element: DataSourceComponent) => element["urlSourcedResultRows"]());
+  public async getDownloadResults(): Promise<ReadonlyArray<Partial<DownloadableResult>>> {
+    return await this.component().evaluate((element: DataSourceComponent) => element["resultRows"]());
   }
 
   public async makeSubSelection(subSelectionIndicies: number[]): Promise<void> {

--- a/src/components/data-source/data-source.spec.ts
+++ b/src/components/data-source/data-source.spec.ts
@@ -47,7 +47,7 @@ test.describe("data source", () => {
 
       test.describe("downloading results", () => {
         test("should have the correct content for results with entire grid decisions", async ({ fixture }) => {
-          const originalFileContent = await fixture.getFileContent();
+          const originalFileContent = await fixture.getDownloadResults();
 
           // we expect that the oe_frog column has been added to the results
           // because we make an additional tags decision where the additional
@@ -75,7 +75,7 @@ test.describe("data source", () => {
         // meaning that the first row should be empty, the second row should
         // have the decision, and the third row should be empty
         test("should have the correct content for results with a sub-selection", async ({ fixture }) => {
-          const originalFileContent = await fixture.getFileContent();
+          const originalFileContent = await fixture.getDownloadResults();
           const subSelectionIndex = 1;
 
           const expectedResult = originalFileContent;

--- a/src/components/decision/classification/classification.fixture.ts
+++ b/src/components/decision/classification/classification.fixture.ts
@@ -1,5 +1,5 @@
 import { Page } from "@playwright/test";
-import { catchEvent, removeBrowserAttribute, setBrowserAttribute } from "../../../tests/helpers";
+import { catchEvent, removeBrowserAttribute, setBrowserAttribute, waitForContentReady } from "../../../tests/helpers";
 import { ClassificationComponent } from "./classification";
 import { DecisionEvent } from "../decision";
 import { test } from "../../../tests/assertions";
@@ -20,8 +20,8 @@ class ClassificationComponentFixture {
   public async create() {
     // pull the tag out of the `tag` attribute
     await this.page.setContent("<oe-classification tag='koala'></oe-classification>");
-    await this.page.waitForLoadState("networkidle");
-    await this.page.waitForSelector("oe-classification");
+
+    await waitForContentReady(this.page, ["oe-classification"]);
 
     // mock the verification grid by binding it to the document object
     // this means that we can test that the shortcut keys work correctly without

--- a/src/components/decision/verification/verification.fixture.ts
+++ b/src/components/decision/verification/verification.fixture.ts
@@ -1,5 +1,11 @@
 import { Page } from "@playwright/test";
-import { catchEvent, removeBrowserAttribute, setBrowserAttribute, setBrowserValue } from "../../../tests/helpers";
+import {
+  catchEvent,
+  removeBrowserAttribute,
+  setBrowserAttribute,
+  setBrowserValue,
+  waitForContentReady,
+} from "../../../tests/helpers";
 import { VerificationComponent } from "./verification";
 import { SelectionObserverType } from "../../verification-grid/verification-grid";
 import { DecisionOptions } from "../../../models/decisions/decision";
@@ -18,8 +24,7 @@ class VerificationComponentFixture {
 
   public async create() {
     await this.page.setContent(`<oe-verification verified="true"></oe-verification>`);
-    await this.page.waitForLoadState("networkidle");
-    await this.page.waitForSelector("oe-verification");
+    await waitForContentReady(this.page, ["oe-verification"]);
 
     // mock the verification grid by binding it to the document object
     // this means that we can test that the shortcut keys work correctly without

--- a/src/components/indicator/indicator.fixture.ts
+++ b/src/components/indicator/indicator.fixture.ts
@@ -1,5 +1,6 @@
 import { Page } from "@playwright/test";
 import { test } from "../../tests/assertions";
+import { waitForContentReady } from "../../tests/helpers";
 
 class TestPage {
   public constructor(public readonly page: Page) {}
@@ -15,8 +16,7 @@ class TestPage {
           <div style="width: 200px; height: 200px;"></div>
         </oe-indicator>
     `);
-    await this.page.waitForLoadState("networkidle");
-    await this.page.waitForSelector("oe-indicator");
+    await waitForContentReady(this.page, ["oe-indicator"]);
   }
 }
 

--- a/src/components/info-card/info-card.fixture.ts
+++ b/src/components/info-card/info-card.fixture.ts
@@ -1,5 +1,5 @@
 import { Page } from "@playwright/test";
-import { getBrowserValue, setBrowserValue } from "../../tests/helpers";
+import { getBrowserValue, setBrowserValue, waitForContentReady } from "../../tests/helpers";
 import { InfoCardComponent } from "./info-card";
 import { Subject, SubjectWrapper } from "../../models/subject";
 import { test } from "../../tests/assertions";
@@ -16,8 +16,7 @@ class TestPage {
 
   public async create() {
     await this.page.setContent(`<oe-info-card></oe-info-card>`);
-    await this.page.waitForLoadState("networkidle");
-    await this.page.waitForSelector("oe-info-card");
+    await waitForContentReady(this.page, ["oe-info-card"]);
   }
 
   public async changeSubject(subject: Subject) {

--- a/src/components/media-controls/media-controls.fixture.ts
+++ b/src/components/media-controls/media-controls.fixture.ts
@@ -2,6 +2,7 @@ import { Page } from "@playwright/test";
 import { MediaControlsComponent } from "./media-controls";
 import { SpectrogramComponent } from "../spectrogram/spectrogram";
 import { test } from "../../tests/assertions";
+import { waitForContentReady } from "../../tests/helpers";
 
 class TestPage {
   public constructor(public readonly page: Page) {}
@@ -22,8 +23,7 @@ class TestPage {
             ${slotTemplate ?? ""}
         </oe-media-controls>
     `);
-    await this.page.waitForLoadState("networkidle");
-    await this.page.waitForSelector("oe-media-controls");
+    await waitForContentReady(this.page, ["oe-media-controls", "oe-spectrogram"]);
   }
 
   public async updateSlot(content: string) {

--- a/src/components/spectrogram/single-spectrogram.fixture.ts
+++ b/src/components/spectrogram/single-spectrogram.fixture.ts
@@ -1,15 +1,15 @@
 import { Page } from "@playwright/test";
 import { SpectrogramComponent } from "./spectrogram";
-import { hasBrowserAttribute } from "../../tests/helpers";
+import { hasBrowserAttribute, waitForContentReady } from "../../tests/helpers";
 import { test } from "../../tests/assertions";
 
 class SingleSpectrogramFixture {
   public constructor(public readonly page: Page) {}
 
-  public spectrogram = this.page.locator("oe-spectrogram").first();
-  public spectrogramAudioElement = this.page.locator("oe-spectrogram #media-element").first();
-  public mediaControls = this.page.locator("oe-media-controls").first();
-  public mediaControlsActionButton = this.page.locator("oe-media-controls #action-button").first();
+  public spectrogram = () => this.page.locator("oe-spectrogram").first();
+  public spectrogramAudioElement = () => this.page.locator("oe-spectrogram #media-element").first();
+  public mediaControls = () => this.page.locator("oe-media-controls").first();
+  public mediaControlsActionButton = () => this.page.locator("oe-media-controls #action-button").first();
   public audioSource = "http://localhost:3000/example.flac";
 
   public async create() {
@@ -17,18 +17,18 @@ class SingleSpectrogramFixture {
         <oe-spectrogram id="spectrogram" src="${this.audioSource}"></oe-spectrogram>
         <oe-media-controls for="spectrogram"></oe-media-controls>
     `);
-    await this.page.waitForLoadState("networkidle");
+    await waitForContentReady(this.page, ["oe-spectrogram", "oe-media-controls"]);
   }
 
   public async updateSlot(content: string) {
-    const componentElement = this.spectrogram;
+    const componentElement = this.spectrogram();
     await componentElement.evaluate((element: HTMLElement, content: string) => {
       element.innerHTML = content;
     }, content);
   }
 
   public async isPlayingAudio(): Promise<boolean> {
-    return !(await hasBrowserAttribute<SpectrogramComponent>(this.spectrogram, "paused"));
+    return !(await hasBrowserAttribute<SpectrogramComponent>(this.spectrogram(), "paused"));
   }
 }
 

--- a/src/components/spectrogram/spectrogram.spec.ts
+++ b/src/components/spectrogram/spectrogram.spec.ts
@@ -98,18 +98,18 @@ fixture.describe("spectrogram", () => {
     const slot = `<source src="${fixture.audioSource}" type="audio/flac" />`;
     await fixture.updateSlot(slot);
 
-    await invokeBrowserMethod<SpectrogramComponent>(fixture.spectrogram, "play");
+    await invokeBrowserMethod<SpectrogramComponent>(fixture.spectrogram(), "play");
     expect(await fixture.isPlayingAudio()).toBe(true);
 
-    await invokeBrowserMethod<SpectrogramComponent>(fixture.spectrogram, "pause");
+    await invokeBrowserMethod<SpectrogramComponent>(fixture.spectrogram(), "pause");
     expect(await fixture.isPlayingAudio()).toBe(false);
   });
 
   fixture("playing and pausing audio with src attribute", async ({ fixture }) => {
-    await invokeBrowserMethod<SpectrogramComponent>(fixture.spectrogram, "play");
+    await invokeBrowserMethod<SpectrogramComponent>(fixture.spectrogram(), "play");
     expect(await fixture.isPlayingAudio()).toBe(true);
 
-    await invokeBrowserMethod<SpectrogramComponent>(fixture.spectrogram, "pause");
+    await invokeBrowserMethod<SpectrogramComponent>(fixture.spectrogram(), "pause");
     expect(await fixture.isPlayingAudio()).toBe(false);
   });
 });

--- a/src/components/verification-grid-settings/verification-grid-settings.fixture.ts
+++ b/src/components/verification-grid-settings/verification-grid-settings.fixture.ts
@@ -5,6 +5,7 @@ import {
   getBrowserValue,
   setBrowserAttribute,
   setBrowserValue,
+  waitForContentReady,
 } from "../../tests/helpers";
 import { VerificationGridSettingsComponent } from "../verification-grid-settings/verification-grid-settings";
 import { VerificationGridComponent } from "../verification-grid/verification-grid";
@@ -26,20 +27,13 @@ class TestPage {
 
   public async create() {
     await this.page.setContent(`
-      <oe-verification-grid id="verification-grid" grid-size="0">
-        <template>
-          <oe-spectrogram></oe-spectrogram>
-        </template>
-      </oe-verification-grid>
+      <oe-verification-grid id="verification-grid" grid-size="0"></oe-verification-grid>
     `);
-    await this.page.waitForLoadState("networkidle");
+    await waitForContentReady(this.page, ["oe-verification-grid", "oe-verification-grid-settings"]);
 
     // because the help dialog is shown over all elements, we have to dismiss
     // it before we can interact with the settings component
     await this.dismissHelpDialogButton().click();
-
-    await this.page.waitForSelector("oe-verification-grid");
-    await this.page.waitForSelector("oe-verification-grid-settings");
   }
 
   public async isFullscreen(): Promise<boolean> {

--- a/src/components/verification-grid-tile/verification-grid-tile.fixture.ts
+++ b/src/components/verification-grid-tile/verification-grid-tile.fixture.ts
@@ -1,5 +1,5 @@
 import { Page } from "@playwright/test";
-import { getBrowserValue } from "../../tests/helpers";
+import { getBrowserValue, waitForContentReady } from "../../tests/helpers";
 import { VerificationGridTileComponent } from "./verification-grid-tile";
 import { test } from "../../tests/assertions";
 
@@ -18,8 +18,7 @@ class VerificationGridTileFixture {
         <oe-spectrogram></oe-spectrogram>
       </oe-verification-grid-tile>
     `);
-    await this.page.waitForLoadState("networkidle");
-    await this.page.waitForSelector("oe-verification-grid-tile");
+    await waitForContentReady(this.page, ["oe-verification-grid-tile", "oe-spectrogram"]);
   }
 
   public async isSelected(): Promise<boolean> {

--- a/src/components/verification-grid/verification-grid.fixture.ts
+++ b/src/components/verification-grid/verification-grid.fixture.ts
@@ -1,5 +1,5 @@
 import { Page } from "@playwright/test";
-import { setBrowserAttribute } from "../../tests/helpers";
+import { setBrowserAttribute, waitForContentReady } from "../../tests/helpers";
 import { VerificationGridComponent } from "./verification-grid";
 import { test } from "../../tests/assertions";
 
@@ -22,8 +22,7 @@ class VerificationGridFixture {
         ></oe-data-source>
       </oe-verification-grid>
     `);
-    await this.page.waitForLoadState("networkidle");
-    await this.page.waitForSelector("oe-verification-grid");
+    await waitForContentReady(this.page, ["oe-verification-grid", "oe-data-source"]);
   }
 
   public async createWithDecisionElements() {
@@ -33,8 +32,8 @@ class VerificationGridFixture {
           <div class="template-element"></div>
         </template>
 
-        <oe-decision verified="true" tag="koala" shortcut="Y">Koala</oe-decision>
-        <oe-decision verified="false" tag="koala" shortcut="N">Not Koala</oe-decision>
+        <oe-verification verified="true" shortcut="Y">Koala</oe-verification>
+        <oe-verification verified="false" shortcut="N">Not Koala</oe-verification>
 
         <oe-data-source
           src="http://localhost:3000/grid-items.json"
@@ -42,8 +41,7 @@ class VerificationGridFixture {
         ></oe-data-source>
       </oe-verification-grid>
     `);
-    await this.page.waitForLoadState("networkidle");
-    await this.page.waitForSelector("oe-verification-grid");
+    await waitForContentReady(this.page, ["oe-verification-grid", "oe-data-source", "oe-verification"]);
   }
 
   public async setGridSize(value: number) {

--- a/src/components/verification-grid/verification-grid.ts
+++ b/src/components/verification-grid/verification-grid.ts
@@ -1327,7 +1327,9 @@ export class VerificationGridComponent extends AbstractComponent(LitElement) {
         tile.model.skipUndecided(hasVerificationTask, requiredTags);
       }
 
-      await this.nextPage();
+      if (!this.isViewingHistory()) {
+        await this.nextPage();
+      }
     };
 
     return html`<button id="skip-button" class="oe-btn-primary" @click="${skipEventHandler}">Skip</button>`;

--- a/src/models/subject.ts
+++ b/src/models/subject.ts
@@ -4,6 +4,13 @@ import { Verification } from "./decisions/verification";
 import { Tag, TagName } from "./tag";
 import { EnumValue } from "../helpers/types/advancedTypes";
 
+export enum AudioCachedState {
+  COLD,
+  REQUESTED,
+  SUCCESS,
+  FAILED,
+}
+
 /** Original unprocessed data from the data source */
 export type Subject = Record<PropertyKey, unknown>;
 
@@ -54,10 +61,10 @@ export class SubjectWrapper {
   public subject: Readonly<Subject>;
 
   /** If the audio has been pre-fetched using a GET request */
-  public clientCached = false;
+  public clientCached = AudioCachedState.COLD;
 
   /** If the audio has been warmed/split on the server using a HEAD request */
-  public serverCached = false;
+  public serverCached = AudioCachedState.COLD;
 
   // each row can only have one verification decision
   // but can have multiple classification decisions

--- a/src/services/subjectParser.spec.ts
+++ b/src/services/subjectParser.spec.ts
@@ -145,7 +145,7 @@ const tests: VerificationParserTest[] = [
 
 test.describe("SubjectParser", () => {
   for (const testItem of tests) {
-    const result = SubjectParser.parse(testItem.input);
+    const result = SubjectParser.parse(testItem.input, (url) => url);
 
     if ("expectedUrl" in testItem) {
       test(`should have the correct url for a ${testItem.name}`, () => {

--- a/src/tests/axes-spectrogram/axes-spectrogram.e2e.fixture.ts
+++ b/src/tests/axes-spectrogram/axes-spectrogram.e2e.fixture.ts
@@ -1,4 +1,4 @@
-import { setBrowserAttribute } from "../helpers";
+import { setBrowserAttribute, waitForContentReady } from "../helpers";
 import { SpectrogramComponent, SpectrogramCanvasScale } from "../../components/spectrogram/spectrogram";
 import { Locator, Page } from "@playwright/test";
 import { Size } from "../../models/rendering";
@@ -29,9 +29,7 @@ class TestPage {
         ></oe-spectrogram>
       </oe-axes>
     `);
-    await this.page.waitForLoadState("networkidle");
-    await this.page.waitForSelector("oe-axes");
-    await this.page.waitForSelector("oe-spectrogram");
+    await waitForContentReady(this.page, ["oe-axes", "oe-spectrogram"]);
   }
 
   public async changeSize(size: Size) {

--- a/src/tests/full-spectrogram/full-spectrogram.e2e.fixture.ts
+++ b/src/tests/full-spectrogram/full-spectrogram.e2e.fixture.ts
@@ -1,6 +1,12 @@
 import { Page } from "@playwright/test";
 import { SpectrogramComponent } from "../../components/spectrogram/spectrogram";
-import { getBrowserAttribute, getBrowserSignalValue, getBrowserValue, setBrowserAttribute } from "../helpers";
+import {
+  getBrowserAttribute,
+  getBrowserSignalValue,
+  getBrowserValue,
+  setBrowserAttribute,
+  waitForContentReady,
+} from "../helpers";
 import { AudioModel } from "../../models/recordings";
 import { test } from "../assertions";
 
@@ -31,7 +37,7 @@ class TestPage {
       </oe-axes>
       <oe-media-controls for="spectrogram"></oe-media-controls>
     `);
-    await this.page.waitForLoadState("networkidle");
+    await waitForContentReady(this.page, ["oe-axes", "oe-indicator", "oe-spectrogram", "oe-media-controls"]);
   }
 
   public async removeElement(selector: string) {

--- a/src/tests/helpers.ts
+++ b/src/tests/helpers.ts
@@ -270,3 +270,12 @@ export async function invokeBrowserMethod<T extends HTMLElement>(
     args,
   );
 }
+
+export async function waitForContentReady(page: Page, selectors: string[] = []): Promise<void> {
+  // wait for the page to emit the "load"
+  await page.waitForLoadState();
+  await Promise.all(selectors.map((selector) => page.waitForSelector(selector)));
+
+  // wait until all network requests have completed
+  await page.waitForLoadState("networkidle");
+}

--- a/src/tests/indicator-spectrogram/indicator-spectrogram-media-controls.e2e.fixture.ts
+++ b/src/tests/indicator-spectrogram/indicator-spectrogram-media-controls.e2e.fixture.ts
@@ -1,5 +1,5 @@
 import { Page } from "@playwright/test";
-import { setBrowserAttribute } from "../helpers";
+import { setBrowserAttribute, waitForContentReady } from "../helpers";
 import { SpectrogramComponent } from "../../components/spectrogram/spectrogram";
 import { test } from "../assertions";
 
@@ -24,9 +24,7 @@ class TestPage {
       <oe-media-controls for="spectrogram"></oe-media-controls>
    `);
 
-    await this.page.waitForSelector("oe-indicator");
-    await this.page.waitForSelector("oe-spectrogram");
-    await this.page.waitForLoadState("networkidle");
+    await waitForContentReady(this.page, ["oe-indicator", "oe-spectrogram", "oe-media-controls"]);
   }
 
   public async removeSpectrogramElement() {

--- a/src/tests/spectrogram-media-controls/spectrogram-media-controls.e2e.fixture.ts
+++ b/src/tests/spectrogram-media-controls/spectrogram-media-controls.e2e.fixture.ts
@@ -1,6 +1,6 @@
 import { Locator, Page } from "@playwright/test";
 import { SpectrogramComponent } from "../../components/spectrogram/spectrogram";
-import { getBrowserValue, hasBrowserAttribute } from "../helpers";
+import { getBrowserValue, hasBrowserAttribute, waitForContentReady } from "../helpers";
 import { test } from "../assertions";
 
 class MultipleSpectrogramFixture {
@@ -28,7 +28,7 @@ class MultipleSpectrogramFixture {
       ></oe-spectrogram>
       <oe-media-controls for="first"></oe-media-controls>
     `);
-    await this.page.waitForLoadState("networkidle");
+    await waitForContentReady(this.page, ["oe-spectrogram", "oe-media-controls"]);
   }
 
   public async createWithSameIds() {
@@ -45,7 +45,7 @@ class MultipleSpectrogramFixture {
       ></oe-spectrogram>
       <oe-media-controls for="first"></oe-media-controls>
     `);
-    await this.page.waitForLoadState("networkidle");
+    await waitForContentReady(this.page, ["oe-spectrogram", "oe-media-controls"]);
   }
 
   public async isPlayingAudio(component: Locator): Promise<boolean> {

--- a/src/tests/verification-grid/verification-grid.e2e.fixture.ts
+++ b/src/tests/verification-grid/verification-grid.e2e.fixture.ts
@@ -10,6 +10,7 @@ import {
   invokeBrowserMethod,
   removeBrowserAttribute,
   setBrowserAttribute,
+  waitForContentReady,
 } from "../helpers";
 import {
   MousePosition,
@@ -118,8 +119,8 @@ class TestPage {
         ></oe-data-source>
       </oe-verification-grid>
     `);
-    await this.page.waitForLoadState("networkidle");
-    await this.page.waitForSelector("oe-verification-grid");
+
+    await waitForContentReady(this.page, ["oe-verification-grid", "oe-data-source", "oe-verification"]);
   }
 
   public async createWithClassificationTask() {
@@ -189,8 +190,13 @@ class TestPage {
     return gridTiles.length;
   }
 
-  public async getPagedItems(): Promise<number> {
-    const pagedItems = await getBrowserValue<VerificationGridComponent>(this.gridComponent(), "pagedItems");
+  public async getViewHead(): Promise<number> {
+    const pagedItems = await getBrowserValue<VerificationGridComponent>(this.gridComponent(), "viewHead");
+    return pagedItems as number;
+  }
+
+  public async getVerificationHead(): Promise<number> {
+    const pagedItems = await getBrowserValue<VerificationGridComponent>(this.gridComponent(), "decisionHead");
     return pagedItems as number;
   }
 
@@ -573,13 +579,6 @@ class TestPage {
 
   public async selectFile() {
     await this.fileInputButton().setInputFiles("file.json");
-  }
-
-  public async userDecisions(): Promise<SubjectWrapper[]> {
-    return (await getBrowserValue<VerificationGridComponent>(
-      this.gridComponent(),
-      "subjectHistory",
-    )) as SubjectWrapper[];
   }
 
   public async getPopulatedGridSize(): Promise<number> {

--- a/webcomponents.code-workspace
+++ b/webcomponents.code-workspace
@@ -68,6 +68,7 @@
       "progressbar",
       "pageerror",
       "spacebar",
+      "appender",
     ],
     "cSpell.flagWords": ["yuo"],
     "cSpell.ignorePaths": ["**/node_modules/**", "**/dist/**", "webcomponents.code-workspace"],


### PR DESCRIPTION
# refactor: Unify view and history subject array

## Changes

- Refactors the verification grids subject history, current page buffers, currentPage, gridPageFetcher, and urlSourcedFetcher subject arrays into a single unified array
- Refactor repetitive test setup tasks, such as waiting for the document's load event, networkIdle state, and selector checks, into a streamlined test helper function.
- Fixes a bug where changing the grid size would cause the subject buffer to be cleared
- Fixes audio-prefetching race condition through a `AudioCachedState` enum that has a "REQUESTED" state
- Fixes a bug where pressing "skip" while viewing history would cause the grid to page
- Adds better handling for failed audio pre-fetching
- Adds tests to assert that sub-selections and subject decisions work correctly after changing the grid size

## Related Issues

Fixes: #139

## Final Checklist

- [ ] All commits messages are semver compliant
- [ ] Added relevant unit tests for new functionality
- [x] Updated existing unit tests to reflect changes
- [x] Code style is consistent with the project guidelines
- [ ] Documentation is updated to reflect the changes (if applicable)
- [x] Link issues related to the PR
- [x] Assign labels if you have permission
- [x] Assign reviewers if you have permission
- [x] Ensure that CI is passing
- [x] Ensure that `pnpm lint` runs without any errors
- [x] Ensure that `pnpm test` runs without any errors
