### PR TITLE
fix: Incorrect file name for local results

### DIFF
--- a/dev/use-cases/nsw.html
+++ b/dev/use-cases/nsw.html
@@ -12,7 +12,7 @@
       <oe-verification verified="true" shortcut="Y"></oe-verification>
       <oe-verification verified="false" shortcut="N"></oe-verification>
 
-      <oe-data-source slot="data-source" for="verification-grid" src="/kaleidoscope.csv"></oe-data-source>
+      <oe-data-source slot="data-source" for="verification-grid" src="/kaleidoscope.csv" local></oe-data-source>
     </oe-verification-grid>
   </body>
 </html>

--- a/src/components/data-source/data-source.ts
+++ b/src/components/data-source/data-source.ts
@@ -23,9 +23,13 @@ import dataSourceStyles from "./css/style.css?inline";
 export class DataSourceComponent extends AbstractComponent(LitElement) {
   public static styles = unsafeCSS(dataSourceStyles);
 
+  // TODO: The polymorphic typing of src (string | File) is a red hearing that
+  // something is wrong with the design of this component.
+  // I originally added "File" to the typing so that when uploading a local file
+  // the src property would have a file object that had the original file name.
   /** A remote JSON or CSV file to use as the data source */
-  @property({ type: String })
-  public src?: string;
+  @property({ reflect: true })
+  public src?: string | File;
 
   /**
    * A verification grid component that the derived page fetcher callback will
@@ -204,7 +208,7 @@ export class DataSourceComponent extends AbstractComponent(LitElement) {
       return;
     }
 
-    this.src = URL.createObjectURL(file);
+    this.src = file;
   }
 
   private async updateVerificationGrid(): Promise<void> {
@@ -257,7 +261,7 @@ export class DataSourceComponent extends AbstractComponent(LitElement) {
           class="hidden"
           type="file"
           accept=".csv,.json"
-          @change="${this.handleFileChange}"
+          @change="${(event: Event) => this.handleFileChange(event)}"
         />
       </span>
     `;

--- a/src/services/urlSourcedFetcher.ts
+++ b/src/services/urlSourcedFetcher.ts
@@ -37,10 +37,16 @@ export class UrlSourcedFetcher {
     return this.file.type ?? this.fileExtensionMediaType(this.file.name);
   }
 
-  public async updateSrc(src: string): Promise<typeof this> {
-    this._src = src;
+  public async updateSrc(newSource: string | File): Promise<typeof this> {
+    if (newSource instanceof File) {
+      this._src = URL.createObjectURL(newSource);
+      this.file = newSource;
+      return this;
+    }
 
-    const response = await fetch(src);
+    this._src = newSource;
+
+    const response = await fetch(newSource);
     if (!response.ok) {
       throw new Error(`Could not fetch data: ${response.statusText} (${response.status})`);
     }
@@ -76,7 +82,7 @@ export class UrlSourcedFetcher {
       throw UrlSourcedFetcher.unsupportedFormatError;
     }
 
-    // to itterate over the dataset, we require the input file to be an array
+    // to iterate over the dataset, we require the input file to be an array
     // of subjects
     // if we do not receive an array of subjects, the urlSourcedFetcher will
     // fallback to an empty dataset and log an error in the console


### PR DESCRIPTION
# fix: Incorrect file name for local results

## Changes

- Fixes a bug where the file name of locally supplied results would be a blob URL
- Changes the `data-source` property to a `string | File` polymorphic type, so that the file name can be different from the `src` url

## Related Issues

Fixes: #261

## Final Checklist

- [x] All commits messages are semver compliant
- [ ] Added relevant unit tests for new functionality
- [ ] Updated existing unit tests to reflect changes
- [x] Code style is consistent with the project guidelines
- [ ] Documentation is updated to reflect the changes (if applicable)
- [x] Link issues related to the PR
- [x] Assign labels if you have permission
- [x] Assign reviewers if you have permission
- [ ] Ensure that CI is passing
- [x] Ensure that `pnpm lint` runs without any errors
- [ ] Ensure that `pnpm test` runs without any errors
