### PR TITLE
fix: Space to play with no grid selection should play all

### DIFF
--- a/src/components/media-controls/media-controls.ts
+++ b/src/components/media-controls/media-controls.ts
@@ -45,6 +45,8 @@ type PreferenceLocation = "default" | "toolbar" | "overflow" | "hidden";
 export class MediaControlsComponent extends AbstractComponent(LitElement) {
   public static styles = unsafeCSS(mediaControlsStyles);
 
+  public static readonly playShortcut = SPACE_KEY;
+
   private static recursiveAxesSearch = (element: HTMLElement): AxesComponent | null => {
     if (element instanceof AxesComponent) {
       return element;
@@ -179,7 +181,7 @@ export class MediaControlsComponent extends AbstractComponent(LitElement) {
       return;
     }
 
-    if (event.key === SPACE_KEY) {
+    if (event.key === MediaControlsComponent.playShortcut) {
       this.toggleAudio(true);
     }
   }
@@ -219,7 +221,7 @@ export class MediaControlsComponent extends AbstractComponent(LitElement) {
             (value) =>
               html`<sl-menu-item
                 type="${value == currentValue ? "checkbox" : "normal"}"
-                value="${value}"
+                value="${value.toString()}"
                 ?checked=${value == currentValue}
               >
                 ${value}

--- a/src/components/media-controls/media-controls.ts
+++ b/src/components/media-controls/media-controls.ts
@@ -76,11 +76,14 @@ export class MediaControlsComponent extends AbstractComponent(LitElement) {
   private optionsChangeHandler = this.handleSpectrogramOptionsChange.bind(this);
 
   public disconnectedCallback(): void {
-    this.spectrogramElement?.removeEventListener(SpectrogramComponent.playEventName, this.playHandler);
-    this.spectrogramElement?.removeEventListener(
-      SpectrogramComponent.optionsChangeEventName,
-      this.optionsChangeHandler,
-    );
+    if (this.spectrogramElement) {
+      this.spectrogramElement?.removeEventListener(SpectrogramComponent.playEventName, this.playHandler);
+      this.spectrogramElement?.removeEventListener(
+        SpectrogramComponent.optionsChangeEventName,
+        this.optionsChangeHandler,
+      );
+    }
+
     document.removeEventListener("keydown", this.keyDownHandler);
 
     super.disconnectedCallback();
@@ -109,7 +112,7 @@ export class MediaControlsComponent extends AbstractComponent(LitElement) {
 
   protected willUpdate(changedProperties: PropertyValues<this>): void {
     if (changedProperties.has("for")) {
-      // unbind the previous spectrogram element from the playing
+      // unbind the previous spectrogram element from the "play" event listener
       this.spectrogramElement?.removeEventListener(SpectrogramComponent.playEventName, this.playHandler);
       this.spectrogramElement?.removeEventListener(
         SpectrogramComponent.optionsChangeEventName,

--- a/src/components/spectrogram/spectrogram.ts
+++ b/src/components/spectrogram/spectrogram.ts
@@ -47,6 +47,7 @@ const domRenderWindowConverter = (value: string | null): RenderWindow | undefine
 export class SpectrogramComponent extends SignalWatcher(AbstractComponent(LitElement)) {
   public static styles = unsafeCSS(spectrogramStyles);
 
+  // TODO: we should also have a "pause" event
   public static readonly playEventName = "play";
   public static readonly loadingEventName = "loading";
   public static readonly loadedEventName = "loaded";

--- a/src/components/spectrogram/spectrogram.ts
+++ b/src/components/spectrogram/spectrogram.ts
@@ -47,10 +47,10 @@ const domRenderWindowConverter = (value: string | null): RenderWindow | undefine
 export class SpectrogramComponent extends SignalWatcher(AbstractComponent(LitElement)) {
   public static styles = unsafeCSS(spectrogramStyles);
 
-  public static readonly playEventName = "play" as const;
-  public static readonly loadingEventName = "loading" as const;
-  public static readonly loadedEventName = "loaded" as const;
-  public static readonly optionsChangeEventName = "options-change" as const;
+  public static readonly playEventName = "play";
+  public static readonly loadingEventName = "loading";
+  public static readonly loadedEventName = "loaded";
+  public static readonly optionsChangeEventName = "options-change";
 
   // must be in the format window="startOffset, lowFrequency, endOffset, highFrequency"
   @property({ attribute: "window", converter: domRenderWindowConverter, reflect: true })
@@ -525,7 +525,16 @@ export class SpectrogramComponent extends SignalWatcher(AbstractComponent(LitEle
 
     // if this event is canceled, the spectrogram will not play
     const eventSuccess = this.dispatchEvent(
-      new CustomEvent<IPlayEvent>(SpectrogramComponent.playEventName, { detail, cancelable: true, bubbles: true }),
+      new CustomEvent<IPlayEvent>(SpectrogramComponent.playEventName, {
+        detail,
+        cancelable: true,
+        bubbles: true,
+
+        // We set composed: true so that the event can bubble through shadow
+        // and light DOM boundaries.
+        // Such as when the spectrogram is templated inside a grid tile
+        composed: true,
+      }),
     );
 
     // if the event is canceled (through event.preventDefault), it means that

--- a/src/components/verification-grid/verification-grid.ts
+++ b/src/components/verification-grid/verification-grid.ts
@@ -631,20 +631,29 @@ export class VerificationGridComponent extends AbstractComponent(LitElement) {
   /**
    * Catches a verification grid tiles play event, and conditionally cancels it
    * based on the current selection state.
+   *
+   * Reminder: The play shortcut is listened for by each media-controls, so this
+   * handler runs grid size times when the play shortcut is pressed.
    */
   private handleTilePlay(event: CustomEvent<IPlayEvent>): void {
-    // If there are no tiles selected, we never want to cancel the play event
-    // this condition is why we cancel play events inside the verification grid
-    // component.
-    // Because if we conditionally cancel the play event inside the grid tile
-    // (upstream), we will never reach this condition to play all tiles if
-    // there is no sub-selection.
+    // If there are no tiles selected, then we want to play everything
+    // so don't cancel any of the play events.
+    // This is handled here and not in the tiles, because the tile's don't know the total
+    // selected count.
     if (this.currentSubSelection.length === 0) {
       return;
     }
 
-    const tile = event.target as VerificationGridTileComponent;
-    if (!tile.selected && event.detail.keyboardShortcut) {
+    const eventTarget = event.target;
+    if (!(eventTarget instanceof VerificationGridTileComponent)) {
+      console.warn("Received play event request from non-tile element");
+      return;
+    }
+
+    // but if some are selected, then cancel the play event for only those that
+    // aren't selected
+    if (!eventTarget.selected && event.detail.keyboardShortcut) {
+      console.log("Cancelling play event for unselected tile", eventTarget.selected);
       event.preventDefault();
     }
   }

--- a/src/components/verification-grid/verification-grid.ts
+++ b/src/components/verification-grid/verification-grid.ts
@@ -32,6 +32,7 @@ import { injectionContext, verificationGridContext } from "../../helpers/constan
 import { UrlTransformer } from "../../services/subjectParser";
 import { VerificationBootstrapComponent } from "bootstrap-modal/bootstrap-modal";
 import verificationGridStyles from "./css/style.css?inline";
+import { IPlayEvent } from "spectrogram/spectrogram";
 
 export type SelectionObserverType = "desktop" | "tablet" | "default";
 
@@ -624,6 +625,27 @@ export class VerificationGridComponent extends AbstractComponent(LitElement) {
     // if (this.showingSelectionShortcuts && !event.altKey) {
     if (this.showingSelectionShortcuts) {
       this.hideSelectionShortcuts();
+    }
+  }
+
+  /**
+   * Catches a verification grid tiles play event, and conditionally cancels it
+   * based on the current selection state.
+   */
+  private handleTilePlay(event: CustomEvent<IPlayEvent>): void {
+    // If there are no tiles selected, we never want to cancel the play event
+    // this condition is why we cancel play events inside the verification grid
+    // component.
+    // Because if we conditionally cancel the play event inside the grid tile
+    // (upstream), we will never reach this condition to play all tiles if
+    // there is no sub-selection.
+    if (this.currentSubSelection.length === 0) {
+      return;
+    }
+
+    const tile = event.target as VerificationGridTileComponent;
+    if (!tile.selected && event.detail.keyboardShortcut) {
+      event.preventDefault();
     }
   }
 
@@ -1378,6 +1400,7 @@ export class VerificationGridComponent extends AbstractComponent(LitElement) {
                   <oe-verification-grid-tile
                     class="grid-tile"
                     @loaded="${this.handleSpectrogramLoaded}"
+                    @play="${this.handleTilePlay}"
                     .requiredDecisions="${this.requiredDecisions}"
                     .model="${subject}"
                     .index="${i}"

--- a/src/helpers/keyboard.ts
+++ b/src/helpers/keyboard.ts
@@ -1,5 +1,5 @@
-export const SPACE_KEY = " " as const;
-export const ENTER_KEY = "Enter" as const;
-export const ESCAPE_KEY = "Escape" as const;
-export const LEFT_ARROW_KEY = "ArrowLeft" as const;
-export const RIGHT_ARROW_KEY = "ArrowRight" as const;
+export const SPACE_KEY = " ";
+export const ENTER_KEY = "Enter";
+export const ESCAPE_KEY = "Escape";
+export const LEFT_ARROW_KEY = "ArrowLeft";
+export const RIGHT_ARROW_KEY = "ArrowRight";

--- a/src/tests/full-spectrogram/full-spectrogram.e2e.fixture.ts
+++ b/src/tests/full-spectrogram/full-spectrogram.e2e.fixture.ts
@@ -9,6 +9,7 @@ import {
 } from "../helpers";
 import { AudioModel } from "../../models/recordings";
 import { test } from "../assertions";
+import { MediaControlsComponent } from "../../components";
 
 // this fixture involves all the components that we have developed interacting together
 // in their expected use cases
@@ -45,9 +46,9 @@ class TestPage {
     await element.evaluate((element) => element.remove());
   }
 
-  public async pressSpaceBar() {
+  public async shortcutPlaySpectrogram() {
     const target = this.spectrogramComponent();
-    await target.press(" ");
+    await target.press(MediaControlsComponent.playShortcut);
   }
 
   public async playAudio() {

--- a/src/tests/verification-grid/verification-grid.e2e.spec.ts
+++ b/src/tests/verification-grid/verification-grid.e2e.spec.ts
@@ -600,6 +600,57 @@ test.describe("single verification grid", () => {
     // test.describe("auto paging", () => {});
   });
 
+  test.describe("playing and pausing tiles", () => {
+    test.describe("no sub-selection", () => {
+      test("should play all tiles when the play shortcut is pressed", async ({ fixture }) => {
+        const expectedPlayingCount = await fixture.getPopulatedGridSize();
+
+        await fixture.shortcutGridPlay();
+        const realizedPlayingStates = await fixture.playingSpectrograms();
+
+        expect(realizedPlayingStates).toHaveLength(expectedPlayingCount);
+      });
+
+      test("should play a single tile in a 1x1 grid with keyboard shortcuts", async ({ fixture }) => {
+        const expectedPlayingCount = 1;
+        await fixture.changeGridSize(1);
+
+        await fixture.shortcutGridPlay();
+
+        const realizedPlayingStates = await fixture.playingSpectrograms();
+        expect(realizedPlayingStates).toHaveLength(expectedPlayingCount);
+      });
+
+      test("should pause all tiles when the pause shortcut is pressed", () => {});
+    });
+
+    test.describe("with sub-selection", () => {
+      const testedSubSelection = [0, 1];
+      test.beforeEach(async ({ fixture }) => {
+        await fixture.createSubSelection(testedSubSelection, ["ControlOrMeta"]);
+      });
+
+      test("should only play selected tiles when the play shortcut is pressed", async ({ fixture }) => {
+        await fixture.shortcutGridPlay();
+        const realizedPlayingStates = await fixture.playingSpectrograms();
+        expect(realizedPlayingStates).toHaveLength(testedSubSelection.length);
+      });
+
+      // in this test, we assert that if two tiles are playing and the user
+      // de-selects one of the tiles, only the selected tile should stop
+      // when the user presses the pause shortcut
+      test("should only pause selected tiles when the pause shortcut is pressed", async ({ fixture }) => {
+        await fixture.shortcutGridPlay();
+
+        await fixture.createSubSelection([1]);
+        await fixture.shortcutGridPause();
+
+        const realizedPlayingStates = await fixture.playingSpectrograms();
+        expect(realizedPlayingStates).toHaveLength(1);
+      });
+    });
+  });
+
   test.describe("sub-selection", () => {
     const commonSelectionTests = () => {
       test("should select a tile when clicked", async ({ fixture }) => {


### PR DESCRIPTION
# fix: Space to play with no grid selection should play all

## Changes

- Pressing space with no selection now makes all tiles in the verification grid play
- The grid tile play event aborter is now in the verification grid (needed to check the grid size)
- Fixes not being able to play a 1x1 verification grid tile with space

## Related Issues

Fixes: #128
Fixes: #258

## Final Checklist

- [ ] All commits messages are semver compliant
- [ ] Added relevant unit tests for new functionality
- [ ] Updated existing unit tests to reflect changes
- [ ] Code style is consistent with the project guidelines
- [ ] Documentation is updated to reflect the changes (if applicable)
- [ ] Link issues related to the PR
- [ ] Assign labels if you have permission
- [ ] Assign reviewers if you have permission
- [ ] Ensure that CI is passing
- [ ] Ensure that `pnpm lint` runs without any errors
- [ ] Ensure that `pnpm test` runs without any errors
