### PR TITLE
Emit SubjectWrapper in verification grid decision-made event

### DIFF
--- a/dev/use-cases/ecosounds.html
+++ b/dev/use-cases/ecosounds.html
@@ -83,6 +83,12 @@
         const verificationGrid = document.querySelector("oe-verification-grid");
         verificationGrid.urlTransformer = createUrlTransformer();
         verificationGrid.getPage = gridPaginator;
+
+        // this is some debug info so that I can see the decision model that is
+        // produced by the verification grid
+        verificationGrid.addEventListener("decision-made", (event) => {
+          console.log("new decision", event);
+        });
       }
 
       window.addEventListener("load", () => setup());

--- a/docs-src/components.11ty.js
+++ b/docs-src/components.11ty.js
@@ -44,7 +44,11 @@ export default class Docs {
                parameters: renderTable("", ["name", "description", "type.text"], m.parameters),
              })),
          )}
-         ${renderTable("Events", ["name", "description"], element.events)}
+         ${renderTable(
+           "Events",
+           ["name", "description", "type.text"],
+           element.events?.filter((e) => e.name !== undefined),
+         )}
          ${renderTable("Slots", [["name", "(default)"], "description"], element.slots)}
          ${renderTable("CSS Shadow Parts", ["name", "description"], element.cssParts)}
          ${renderTable("CSS Custom Properties", ["name", "description"], element.cssProperties)}

--- a/src/components/decision/classification/classification.ts
+++ b/src/components/decision/classification/classification.ts
@@ -27,7 +27,7 @@ import classificationStyles from "./css/style.css?inline";
  * @csspart true-decision-button - Styling selector to target the true decision button
  * @csspart false-decision-button - Styling selector to target the false decision button
  *
- * @fires decision
+ * @event decision
  */
 @customElement("oe-classification")
 export class ClassificationComponent extends DecisionComponent {

--- a/src/components/decision/decision.ts
+++ b/src/components/decision/decision.ts
@@ -34,7 +34,7 @@ export type DecisionComponentUnion = DecisionComponent | VerificationComponent |
  * types of decisions.
  * e.g. a verification decision or a classification decision
  *
- * @fires decision
+ * @event decision
  */
 @customElement("oe-decision")
 export abstract class DecisionComponent extends AbstractComponent(LitElement) {

--- a/src/components/decision/verification/verification.ts
+++ b/src/components/decision/verification/verification.ts
@@ -19,7 +19,7 @@ import { Tag } from "../../../models/tag";
  *
  * @csspart decision-button - The button that triggers the decision
  *
- * @fires decision
+ * @event decision
  */
 @customElement("oe-verification")
 export class VerificationComponent extends DecisionComponent {

--- a/src/components/spectrogram/spectrogram.ts
+++ b/src/components/spectrogram/spectrogram.ts
@@ -38,8 +38,8 @@ const domRenderWindowConverter = (value: string | null): RenderWindow | undefine
  * @description
  * A spectrogram component that can be used with the open ecoacoustics components
  *
- * @fires Loading
- * @fires Finished
+ * @event Loading
+ * @event Finished
  *
  * @slot - A `<source>` element to provide the audio source
  */

--- a/src/components/verification-grid-tile/verification-grid-tile.ts
+++ b/src/components/verification-grid-tile/verification-grid-tile.ts
@@ -60,7 +60,7 @@ const shortcutTranslation = {
  * @cssproperty [--selected-border-size] - The size of the border when a
  * decision is being shown
  *
- * @fires Loaded
+ * @event Loaded
  */
 @customElement("oe-verification-grid-tile")
 export class VerificationGridTileComponent extends SignalWatcher(AbstractComponent(LitElement)) {

--- a/src/components/verification-grid/verification-grid.ts
+++ b/src/components/verification-grid/verification-grid.ts
@@ -100,8 +100,8 @@ interface CurrentPage {
  * @slot - Decision elements that will be used to create the decision buttons
  * @slot data-source - An `oe-data-source` element that provides the data
  *
- * @fires decision-made - Emits information about the decision that was made
- * @fires loaded - Emits when all the spectrograms have been loaded
+ * @event { SubjectModel[] } decision-made - Emits information about the decision that was made
+ * @event loaded - Emits when all the spectrograms have been loaded
  */
 @customElement("oe-verification-grid")
 export class VerificationGridComponent extends AbstractComponent(LitElement) {

--- a/src/tests/helpers.ts
+++ b/src/tests/helpers.ts
@@ -192,7 +192,7 @@ export async function catchEvent<T extends Event>(locator: Page, name: string) {
 export async function catchLocatorEvent<T extends Event>(locator: Locator, name: string): Promise<T> {
   return locator.evaluate((element: HTMLElement, name: string) => {
     return new Promise((resolve) => {
-      element.addEventListener(name, (data) => resolve(data));
+      element.addEventListener(name, (data) => resolve(data.detail));
     });
   }, name);
 }

--- a/src/tests/verification-grid/verification-grid.e2e.spec.ts
+++ b/src/tests/verification-grid/verification-grid.e2e.spec.ts
@@ -1365,6 +1365,24 @@ test.describe("decisions", () => {
       },
     ]);
   });
+
+  test("should emit the correct event", async ({ fixture }) => {
+    const targetTile = 0;
+
+    const decisionEvent = catchLocatorEvent<CustomEvent<SubjectWrapper[]>>(fixture.gridComponent(), "decision-made");
+    await fixture.createSubSelection([0]);
+    await fixture.makeDecision(targetTile);
+
+    const gridTiles = await fixture.gridTileComponents();
+    const targetGridTile = gridTiles[targetTile];
+    const expectedSubjectWrapper = (await getBrowserValue<VerificationGridTileComponent>(
+      targetGridTile,
+      "model",
+    )) as SubjectWrapper;
+
+    const realizedEvent = await decisionEvent;
+    expect(realizedEvent).toEqual([expectedSubjectWrapper]);
+  });
 });
 
 test.describe("decision meter", () => {


### PR DESCRIPTION
# Emit SubjectWrapper in verification grid decision-made event

At the moment the verification grid `decision-made` event emits a tuple of `[VerificationGridTile, DecisionModel]`. This is poor form for multiple reasons such as:

- The verification grid tile is an internal component, and should not be exposed to the user
- Emitting a tuple is not ergonomic
- Using the verification grid tile reference to get the subject model is error-prone. Because if the verification grid auto-pages before the subject model could be evaluated, it could change

## Changes

- The verification-grids `decision-made` event now emits a `SubjectWrapper` model which contains the `tag`, `subject`, `verification`, and `classification` models

## Related Issues

Fixes: #294

## Final Checklist

- [ ] All commits messages are semver compliant
- [ ] Added relevant unit tests for new functionality
- [ ] Updated existing unit tests to reflect changes
- [x] Code style is consistent with the project guidelines
- [ ] Documentation is updated to reflect the changes (if applicable)
- [x] Link issues related to the PR
- [x] Assign labels if you have permission
- [x] Assign reviewers if you have permission
- [ ] Ensure that CI is passing
- [x] Ensure that `pnpm lint` runs without any errors
- [ ] Ensure that `pnpm test` runs without any errors
