### PR TITLE
fix(docs): Outdated and inconsistent examples

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,18 +10,6 @@ A short description of the pull request
 - Example feature
 - Example feature
 
-### Bug Fixes
-
-- Example Bug Fix
-- Example Bug Fix
-- Example Bug Fix
-
-### Code Quality
-
-- Example Code Quality Change
-- Example Code Quality Change
-- Example Code Quality Change
-
 ### Remaining Bugs / Unresolved Problems
 
 ## Visual Changes
@@ -38,8 +26,6 @@ A short description of the pull request
 ## Related Issues
 
 Fixes: #xyz
-
-## Additional Notes
 
 ## Final Checklist
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           set -e
           mkdir -p ./dist
-          zip -r ./dist/components.zip ./assets/ ./@types/ ./components.js -x "**/node_modules/*"
+          zip -r ./dist/components.zip ./assets/ ./@types/ ./dist/ ./dist/components.js -x "**/node_modules/*"
           gh release upload ${{ inputs.tag_name }} ./dist/components.zip
 
   Publish-Documentation:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           set -e
           mkdir -p ./dist
-          zip -r ./dist/components.zip ./assets/ ./@types/ ./dist/ ./dist/components.js -x "**/node_modules/*"
+          zip -r ./dist/components.zip ./assets/ ./@types/ ./dist/
           gh release upload ${{ inputs.tag_name }} ./dist/components.zip
 
   Publish-Documentation:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You can import all the web components through the CDN
 Script tag snippet:
 
 ```html
-<script type="module" src="https://cdn.jsdelivr.net/npm/@ecoacoustics/web-components/components.js"></script>
+<script type="module" src="https://esm.run/@ecoacoustics/web-components"></script>
 ```
 
 Full page example:
@@ -28,7 +28,7 @@ Full page example:
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Web Component CDN Example</title>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ecoacoustics/web-components/components.js"></script>
+    <script type="module" src="https://esm.run/@ecoacoustics/web-components"></script>
   </head>
 
   <body>

--- a/dev/cdn.html
+++ b/dev/cdn.html
@@ -7,7 +7,8 @@
     <!-- <script type="module" src="https://esm.run/@ecoacoustics/web-components/dist/components.js"></script> -->
 
     <!-- Does not work because it tries to import the buffer-builder-processor incorrectly -->
-    <script type="module" src="https://esm.run/@ecoacoustics/web-components"></script>
+    <!-- <script type="module" src="https://esm.run/@ecoacoustics/web-components"></script> -->
+    <script type="module" src="https://esm.run/@ecoacoustics/web-components/dist/components.js"></script>
   </head>
 
   <body>

--- a/docs-src/examples/create-verification-grid.md
+++ b/docs-src/examples/create-verification-grid.md
@@ -23,8 +23,8 @@ Along with additional information on how to customize it to your needs.
 
   <body>
     <oe-verification-grid id="verification-grid" grid-size="3" selection-behavior="desktop">
-      <oe-verification verified="true" shortcut="Y">Grey-headed flying fox</oe-verification>
-      <oe-verification verified="false" shortcut="N">Grey-headed flying fox</oe-verification>
+      <oe-verification verified="true" shortcut="y">Grey-headed flying fox</oe-verification>
+      <oe-verification verified="false" shortcut="n">Grey-headed flying fox</oe-verification>
     </oe-verification-grid>
 
     <oe-data-source for="verification-grid" local></oe-data-source>

--- a/docs-src/index.md
+++ b/docs-src/index.md
@@ -18,7 +18,7 @@ To use the CDN, simply add the following code into the `<head>` tag of your webs
 ### Install via NPM
 
 ```sh
-$ npm i @ecoacoustics/webcomponents-workspace
+$ npm i @ecoacoustics/web-components
 >
 ```
 

--- a/docs-src/spectrogram-creator/index.md
+++ b/docs-src/spectrogram-creator/index.md
@@ -280,12 +280,11 @@ function updateAttribute(attribute, value) {
 
 function booleanAttribute(attribute, show) {
   const shouldShow = show === "true";
-  const spectrogram = spectrogram();
 
   if (shouldShow) {
-    spectrogram.setAttribute(attribute, "");
+    spectrogram().setAttribute(attribute, "");
   } else {
-    spectrogram.removeAttribute(attribute);
+    spectrogram().removeAttribute(attribute);
   }
 }
 


### PR DESCRIPTION
# fix(docs): Outdated and inconsistent examples

This repository used to be named webcomponents-workspace, but we have since changed the name to web-components. However, some documentation still used the old (incorrect) package name.

Additionally, the documentation was inconsistent about what CDN path people should use.

This PR updates old references to the old `webcomponent-workspace` repo, and unifies the messaging on what CDN path to use.

## Related Issues

Fixes: #310

## Final Checklist

- [ ] All commits messages are semver compliant
- [ ] Added relevant unit tests for new functionality
- [ ] Updated existing unit tests to reflect changes
- [ ] Code style is consistent with the project guidelines
- [ ] Documentation is updated to reflect the changes (if applicable)
- [ ] Link issues related to the PR
- [ ] Assign labels if you have permission
- [ ] Assign reviewers if you have permission
- [ ] Ensure that CI is passing
- [ ] Ensure that `pnpm lint` runs without any errors
- [ ] Ensure that `pnpm test` runs without any errors
