### PR TITLE
docs: Deprecate esm.run from cdn documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You can import all the web components through the CDN
 Script tag snippet:
 
 ```html
-<script type="module" src="https://esm.run/@ecoacoustics/web-components"></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/@ecoacoustics/web-components/dist/components.js"></script>
 ```
 
 Full page example:
@@ -28,7 +28,7 @@ Full page example:
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Web Component CDN Example</title>
-    <script type="module" src="https://esm.run/@ecoacoustics/web-components"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ecoacoustics/web-components/dist/components.js"></script>
   </head>
 
   <body>

--- a/dev/cdn.html
+++ b/dev/cdn.html
@@ -4,11 +4,14 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Web Components - CDN Test</title>
-    <!-- <script type="module" src="https://esm.run/@ecoacoustics/web-components/dist/components.js"></script> -->
-
+    
     <!-- Does not work because it tries to import the buffer-builder-processor incorrectly -->
     <!-- <script type="module" src="https://esm.run/@ecoacoustics/web-components"></script> -->
-    <script type="module" src="https://esm.run/@ecoacoustics/web-components/dist/components.js"></script>
+    <!-- <script type="module" src="https://esm.run/@ecoacoustics/web-components/dist/components.js"></script> -->
+    <!-- <script type="module" src="https://cdn.jsdelivr.net/npm/@ecoacoustics/web-components@2.0.0/dist/components.js/+esm"></script> -->
+
+    <!-- ! Use this cdn -->
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ecoacoustics/web-components/dist/components.js"></script>
   </head>
 
   <body>

--- a/docs-src/examples/create-verification-grid.md
+++ b/docs-src/examples/create-verification-grid.md
@@ -18,7 +18,7 @@ Along with additional information on how to customize it to your needs.
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>OE Bat Verification Grid</title>
-    <script type="module" src="https://esm.run/@ecoacoustics/web-components"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ecoacoustics/web-components/dist/components.js"></script>
   </head>
 
   <body>

--- a/docs-src/index.md
+++ b/docs-src/index.md
@@ -12,7 +12,7 @@ All JavaScript files are automatically deployed [jsdelivr](https://www.jsdelivr.
 To use the CDN, simply add the following code into the `<head>` tag of your website
 
 ```html
-<script type="module" src="https://esm.run/@ecoacoustics/web-components"></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/@ecoacoustics/web-components/dist/components.js"></script>
 ```
 
 ### Install via NPM


### PR DESCRIPTION
# docs: Deprecate esm.run from cdn documentation

This pull request removes all references to esm.run from the documentation.

`esm.run` breaks audio worklet dynamic imports

## Related Issues

Fixes: #313

## Final Checklist

- [ ] All commits messages are semver compliant
- [ ] Added relevant unit tests for new functionality
- [ ] Updated existing unit tests to reflect changes
- [ ] Code style is consistent with the project guidelines
- [ ] Documentation is updated to reflect the changes (if applicable)
- [ ] Link issues related to the PR
- [ ] Assign labels if you have permission
- [ ] Assign reviewers if you have permission
- [ ] Ensure that CI is passing
- [ ] Ensure that `pnpm lint` runs without any errors
- [ ] Ensure that `pnpm test` runs without any errors
