### PR TITLE
fix: Local .csv data sources not being recognised

### DIFF
--- a/src/services/urlSourcedFetcher.ts
+++ b/src/services/urlSourcedFetcher.ts
@@ -77,12 +77,17 @@ export class UrlSourcedFetcher {
     } else if (this.mediaType.startsWith("text/csv")) {
       models = await csv({ flatKeys: true }).fromString(content);
     } else if (this.mediaType.startsWith("application/vnd.ms-excel") && this.file.name.endsWith(".csv")) {
-      // Windows can sometimes report the file type of a csv as an
-      // application/vnd.ms-excel file type.
+      // On Windows, Firefox uses the MIME Database to determine the media type
+      // of a file.
+      // However, when Excel is installed, it can overwrite the datatype for
+      // csv files to application/vnd.ms-excel.
+      //
       // Therefore, if the file type is reported as "excel" and the file
-      // extension is .csv, it is safe to assume that Windows is incorrectly
-      // reporting the csv file as an excel file and we can really parse it with
-      // our csv parser.
+      // extension is .csv, it is safe to assume that the file type was
+      // overwritten by an excel install and we can parse the file as a csv.
+      //
+      // see: https://support.mozilla.org/en-US/questions/1401889
+      // see: https://bugzilla.mozilla.org/show_bug.cgi?id=1934918
       models = await csv({ flatKeys: true }).fromString(content);
     } else if (this.mediaType.startsWith("text/tab-separated-values")) {
       models = await csv({ flatKeys: true, delimiter: "\t" }).fromString(content);

--- a/src/services/urlSourcedFetcher.ts
+++ b/src/services/urlSourcedFetcher.ts
@@ -76,6 +76,14 @@ export class UrlSourcedFetcher {
       models = JSON.parse(content);
     } else if (this.mediaType.startsWith("text/csv")) {
       models = await csv({ flatKeys: true }).fromString(content);
+    } else if (this.mediaType.startsWith("application/vnd.ms-excel") && this.file.name.endsWith(".csv")) {
+      // Windows can sometimes report the file type of a csv as an
+      // application/vnd.ms-excel file type.
+      // Therefore, if the file type is reported as "excel" and the file
+      // extension is .csv, it is safe to assume that Windows is incorrectly
+      // reporting the csv file as an excel file and we can really parse it with
+      // our csv parser.
+      models = await csv({ flatKeys: true }).fromString(content);
     } else if (this.mediaType.startsWith("text/tab-separated-values")) {
       models = await csv({ flatKeys: true, delimiter: "\t" }).fromString(content);
     } else {


### PR DESCRIPTION
# fix: Local .csv data sources not being recognised

Firefox ESR on Windows was reporting .csv file types as excel files. To fix this, we now check if an "excel" file type also has a .csv extension. It does, we parse the file as a csv file.

## Changes

- If an "excel" file type is uploaded with the ".csv" extension, we attempt to parse the file as a csv. This was done because Firefox ESR on Windows reports csv files as an "application/vnd.ms-excel" file type.

## Problems

We currently have tests to cover this, but CI only tests against greenfield versions of the browsers, meaning that this bug was not caught during testing / ci.

Adding ESR versions of Firefox and Chrome to CI would have caught this bug, but adding these browsers would double CI expenses for not much additional benefit.

## Related Issues

Fixes: #243

## Final Checklist

- [x] All commits messages are semver compliant
- [ ] Added relevant unit tests for new functionality
- [ ] Updated existing unit tests to reflect changes
- [x] Code style is consistent with the project guidelines
- [ ] Documentation is updated to reflect the changes (if applicable)
- [x] Link issues related to the PR
- [x] Assign labels if you have permission
- [x] Assign reviewers if you have permission
- [x] Ensure that CI is passing
- [x] Ensure that `pnpm lint` runs without any errors
- [x] Ensure that `pnpm test` runs without any errors
