### PR TITLE
feat: Slottable oe-data-source downloads button

### DIFF
--- a/dev/use-cases/ecosounds.html
+++ b/dev/use-cases/ecosounds.html
@@ -22,7 +22,9 @@
       <oe-verification verified="true" shortcut="Y"></oe-verification>
       <oe-verification verified="false" shortcut="N"></oe-verification>
 
-      <oe-data-source slot="data-source" for="verification-grid" allow-downloads="false"></oe-data-source>
+      <oe-data-source slot="data-source" for="verification-grid">
+        <button onclick="alert('Placeholder')">Slottable Downloads Button</button>
+      </oe-data-source>
     </oe-verification-grid>
 
     <footer>


### PR DESCRIPTION
# feat: Slottable oe-data-source downloads button

## Changes

- Allows a slottable download button in the default `oe-data-source` slot
- Changes the resultRows() data-source component method to public because consumers might want to get the results of the verification grid for their own custom download button.

## Related Issues

Fixes: #383

## Final Checklist

- [ ] All commits messages are semver compliant
- [ ] Added relevant unit tests for new functionality
- [ ] Updated existing unit tests to reflect changes
- [ ] Code style is consistent with the project guidelines
- [ ] Documentation is updated to reflect the changes (if applicable)
- [ ] Link issues related to the PR
- [ ] Assign labels if you have permission
- [ ] Assign reviewers if you have permission
- [ ] Ensure that CI is passing
- [ ] Ensure that `pnpm lint` runs without any errors
- [ ] Ensure that `pnpm test` runs without any errors
