### PR TITLE
fix: Don't show "pointer" cursor on 1x1 grids

### DIFF
--- a/src/components/verification-grid-tile/css/style.css
+++ b/src/components/verification-grid-tile/css/style.css
@@ -25,7 +25,6 @@
   position: relative;
   border-radius: var(--oe-border-rounding);
   box-shadow: var(--oe-backdrop-shadow) var(--oe-panel-color);
-  cursor: pointer;
   margin-bottom: 0;
   padding: var(--selected-border-size);
   background-color: var(--oe-panel-color);
@@ -75,6 +74,10 @@
 /* TODO: maybe add a border here */
 .selected {
   background-color: var(--oe-selected-color);
+}
+
+.selectable {
+  cursor: pointer;
 }
 
 .hidden {

--- a/src/components/verification-grid-tile/verification-grid-tile.fixture.ts
+++ b/src/components/verification-grid-tile/verification-grid-tile.fixture.ts
@@ -1,7 +1,6 @@
 import { Page } from "@playwright/test";
-import { getBrowserValue, waitForContentReady } from "../../tests/helpers";
-import { VerificationGridTileComponent } from "./verification-grid-tile";
-import { test } from "../../tests/assertions";
+import { getBrowserStyle, waitForContentReady } from "../../tests/helpers";
+import { expect, test } from "../../tests/assertions";
 
 class VerificationGridTileFixture {
   public constructor(public readonly page: Page) {}
@@ -9,50 +8,28 @@ class VerificationGridTileFixture {
   public component = () => this.page.locator("oe-verification-grid-tile").first();
   public tileContainer = () => this.component().locator(".tile-container").first();
 
-  public async create() {
-    // because the grid tile component can't work without a spectrogram
-    // it is reasonable to have a spectrogram and grid tile component in these
-    // integration tests
-    await this.page.setContent(`
-      <oe-verification-grid-tile>
-        <oe-spectrogram></oe-spectrogram>
-      </oe-verification-grid-tile>
-    `);
-    await waitForContentReady(this.page, ["oe-verification-grid-tile", "oe-spectrogram"]);
+  public async create(content?: string) {
+    // The verification grid exists in this test fixture so that we don't have
+    // to mock the "settings" context.
+    //
+    // TODO: Figure out how to mock the settings context and remove the
+    // verification grid component.
+    const defaultContent = `
+      <oe-verification-grid grid-size="1">
+        <oe-verification-grid-tile></oe-verification-grid-tile>
+      </oe-verification-grid>
+    `;
+
+    await this.page.setContent(content ?? defaultContent);
+    await waitForContentReady(this.page, ["oe-verification-grid-tile"]);
   }
 
-  public async isSelected(): Promise<boolean> {
-    return await getBrowserValue<VerificationGridTileComponent, boolean>(this.component(), "selected");
+  public async assertCursor(expectedCursor: string) {
+    // getBrowserStyles uses getComputedStyles and can therefore assert that the
+    // correct cursor is applied, even if it comes from the user agent styles.
+    const realizedCursor = await getBrowserStyle(this.tileContainer(), "cursor");
+    expect(realizedCursor).toEqual(expectedCursor);
   }
-
-  // TODO: Fix this
-  // public async getSelectionShortcut(): Promise<string> {
-  //   return (
-  //     ((await getBrowserValue<VerificationGridTileComponent>(this.component(), "shortcuts")) as string[]).at(-1) ?? ""
-  //   );
-  // }
-
-  // public async getDecisionColor() {
-  //   return await getBrowserValue<VerificationGridTileComponent>(this.component(), "color");
-  // }
-
-  // public async getTileStyles() {
-  //   return await getBrowserStyles<HTMLDivElement>(this.tileContainer());
-  // }
-
-  // // actions
-  // public async mouseSelectSpectrogramTile() {
-  //   await this.tileContainer().click({ force: true });
-  // }
-
-  // public async keyboardSelectSpectrogramTile() {
-  //   const keyboardShortcut = await this.getSelectionShortcut();
-  //   await this.page.keyboard.press(keyboardShortcut);
-  // }
-
-  // public async setDecisionColor(value: string) {
-  //   await setBrowserValue<VerificationGridTileComponent>(this.tileContainer(), "color", value);
-  // }
 }
 
 export const verificationGridTileFixture = test.extend<{ fixture: VerificationGridTileFixture }>({

--- a/src/components/verification-grid-tile/verification-grid-tile.spec.ts
+++ b/src/components/verification-grid-tile/verification-grid-tile.spec.ts
@@ -1,41 +1,16 @@
 import { verificationGridTileFixture as test } from "./verification-grid-tile.fixture";
-import { expect } from "../../tests/assertions";
+import { setBrowserValue } from "../../tests/helpers";
 
 test.describe("verification grid tile", () => {
-  test.beforeEach(async ({ fixture }) => {
+  test("should use a cursor pointer if it is not the only grid tile", async ({ fixture }) => {
     await fixture.create();
+    await setBrowserValue(fixture.component(), "isOnlyTile", false);
+    await fixture.assertCursor("pointer");
   });
 
-  [false, true].forEach((useShortcutKeys: boolean) => {
-    const shortcutKeysText = useShortcutKeys ? "with shortcut keys" : "key mouse click";
-    const selectionStrategy = (fixture: any) =>
-      useShortcutKeys ? fixture.keyboardSelectSpectrogramTile() : fixture.mouseSelectSpectrogramTile();
-
-    test.describe(`selection ${shortcutKeysText}`, () => {
-      test.skip(`should select the tile ${shortcutKeysText}`, async ({ fixture }) => {
-        await selectionStrategy(fixture);
-        expect(await fixture.isSelected()).toBe(true);
-      });
-
-      test.skip(`should select the tile when the ctrl key is pressed ${shortcutKeysText}`, () => {});
-
-      test.skip(`should select the tile when the shift key is pressed ${shortcutKeysText}`, () => {});
-
-      test.skip(`should select the tile when the ctrl and shift keys are pressed ${shortcutKeysText}`, () => {});
-
-      test.skip(`should not change the selection state if the tile is already selected ${shortcutKeysText}`, () => {});
-
-      test.skip(`should be able to deselect the tile using the ctrl key ${shortcutKeysText}`, () => {});
-    });
+  test("should use a normal cursor if it is the only grid tile", async ({ fixture }) => {
+    await fixture.create();
+    await setBrowserValue(fixture.component(), "isOnlyTile", true);
+    await fixture.assertCursor("auto");
   });
-
-  test.skip("should show selection highlight when selected", () => {});
-
-  test.skip("should show the decision color correctly", () => {});
-
-  test.skip("should show keyboard shortcuts when the alt key is held down", () => {});
-
-  test.skip("should be able to use the spacebar to play audio", () => {});
-
-  test.skip("should be able to use the spacebar to pause audio", () => {});
 });

--- a/src/components/verification-grid-tile/verification-grid-tile.ts
+++ b/src/components/verification-grid-tile/verification-grid-tile.ts
@@ -104,6 +104,14 @@ export class VerificationGridTileComponent extends SignalWatcher(WithShoelace(Ab
   @property({ attribute: false, type: Number })
   public index = 0;
 
+  /**
+   * A property that can be set if the grid tile is the only tile in the
+   * verification grid.
+   * This is useful for disabling selection events and styling.
+   */
+  @property({ attribute: false, type: Boolean })
+  public isOnlyTile = false;
+
   @property({ attribute: false, type: Array })
   public readonly requiredDecisions: RequiredDecision[] = [];
 
@@ -361,6 +369,7 @@ export class VerificationGridTileComponent extends SignalWatcher(WithShoelace(Ab
 
     const tileClasses = classMap({
       selected: this.selected,
+      selectable: !this.isOnlyTile,
       hidden: this.hidden,
     });
 

--- a/src/components/verification-grid/verification-grid.ts
+++ b/src/components/verification-grid/verification-grid.ts
@@ -1493,6 +1493,7 @@ export class VerificationGridComponent extends WithShoelace(AbstractComponent(Li
                     @loaded="${this.handleSpectrogramLoaded}"
                     @play="${this.handleTilePlay}"
                     .requiredDecisions="${this.requiredDecisions}"
+                    .isOnlyTile="${this.populatedTileCount === 1}"
                     .model="${subject as any}"
                     .index="${i}"
                   >


### PR DESCRIPTION
# fix: Don't show "pointer" cursor on 1x1 grids

## Changes

- Adds `isOnlyTile` property to `oe-verification-grid-tile` component
- Use the `auto` cursor on when on a 1x1 grid
- Removes a lot of skipped tests that are currently tested in the `verification-grid.e2e.spec` tests

## Related Issues

Fixes: #386

## Final Checklist

- [x] All commits messages are semver compliant
- [x] Added relevant unit tests for new functionality
- [x] Updated existing unit tests to reflect changes
- [x] Code style is consistent with the project guidelines
- [ ] Documentation is updated to reflect the changes (if applicable)
- [x] Link issues related to the PR
- [x] Assign labels if you have permission
- [x] Assign reviewers if you have permission
- [x] Ensure that CI is passing
- [x] Ensure that `pnpm lint` runs without any errors
- [x] Ensure that `pnpm test` runs without any errors
