### PR TITLE
feat: element ref ability inmedia-controls "for"

### DIFF
--- a/src/components/media-controls/media-controls.fixture.ts
+++ b/src/components/media-controls/media-controls.fixture.ts
@@ -12,7 +12,11 @@ class TestPage {
   public actionButtonSlot = () => this.page.locator("oe-media-controls #action-button > slot").first();
   public spectrogram = () => this.page.locator("oe-spectrogram").first();
 
-  public async create(slotTemplate = "") {
+  /**
+   * Creates a test fixture where the media controls is linked to the
+   * spectrogram by passing a spectrogram id to the "for" attribute.
+   */
+  public async createWithId(slotTemplate = "") {
     await this.page.setContent(`
         <oe-spectrogram
           id="spectrogram"
@@ -24,6 +28,30 @@ class TestPage {
         </oe-media-controls>
     `);
     await waitForContentReady(this.page, ["oe-media-controls", "oe-spectrogram"]);
+  }
+
+  /**
+   * Creates a test fixture where the media controls is linked to the
+   * spectrogram by passing an element reference to the "for" property.
+   */
+  public async createWithRef() {
+    await this.page.setContent(`
+        <oe-spectrogram
+          id="spectrogram"
+          src="http://localhost:3000/example.flac"
+          style="display: relative; width: 100px; height: 100px;"
+        ></oe-spectrogram>
+        <oe-media-controls></oe-media-controls>
+    `);
+    await waitForContentReady(this.page, ["oe-media-controls", "oe-spectrogram"]);
+
+    await this.spectrogram().evaluate((spectrogramElement: SpectrogramComponent) => {
+      // We know that the media controls component will exist because we created
+      // it in the fixture above.
+      // Therefore, it is safe to type cast.
+      const mediaControls = document.querySelector("oe-media-controls") as MediaControlsComponent;
+      mediaControls.for = spectrogramElement;
+    });
   }
 
   public async updateSlot(content: string) {
@@ -72,7 +100,7 @@ class TestPage {
 export const mediaControlsFixture = test.extend<{ fixture: TestPage }>({
   fixture: async ({ page }, run) => {
     const fixture = new TestPage(page);
-    await fixture.create();
+    await fixture.createWithId();
     await run(fixture);
   },
 });

--- a/src/components/media-controls/media-controls.fixture.ts
+++ b/src/components/media-controls/media-controls.fixture.ts
@@ -1,8 +1,8 @@
 import { Page } from "@playwright/test";
 import { MediaControlsComponent } from "./media-controls";
 import { SpectrogramComponent } from "../spectrogram/spectrogram";
-import { test } from "../../tests/assertions";
-import { waitForContentReady } from "../../tests/helpers";
+import { expect, test } from "../../tests/assertions";
+import { setBrowserAttribute, waitForContentReady } from "../../tests/helpers";
 
 class TestPage {
   public constructor(public readonly page: Page) {}
@@ -12,6 +12,8 @@ class TestPage {
   public actionButtonSlot = () => this.page.locator("oe-media-controls #action-button > slot").first();
   public spectrogram = () => this.page.locator("oe-spectrogram").first();
 
+  public spectrogramId = "spectrogram";
+
   /**
    * Creates a test fixture where the media controls is linked to the
    * spectrogram by passing a spectrogram id to the "for" attribute.
@@ -19,7 +21,7 @@ class TestPage {
   public async createWithId(slotTemplate = "") {
     await this.page.setContent(`
         <oe-spectrogram
-          id="spectrogram"
+          id="${this.spectrogramId}"
           src="http://localhost:3000/example.flac"
           style="display: relative; width: 100px; height: 100px;"
         ></oe-spectrogram>
@@ -27,7 +29,7 @@ class TestPage {
             ${slotTemplate ?? ""}
         </oe-media-controls>
     `);
-    await waitForContentReady(this.page, ["oe-media-controls", "oe-spectrogram"]);
+    await this.waitUntilLoaded();
   }
 
   /**
@@ -37,14 +39,19 @@ class TestPage {
   public async createWithRef() {
     await this.page.setContent(`
         <oe-spectrogram
-          id="spectrogram"
+          id="${this.spectrogramId}"
           src="http://localhost:3000/example.flac"
           style="display: relative; width: 100px; height: 100px;"
         ></oe-spectrogram>
         <oe-media-controls></oe-media-controls>
     `);
-    await waitForContentReady(this.page, ["oe-media-controls", "oe-spectrogram"]);
+    await this.waitUntilLoaded();
 
+    await this.setForElementReference();
+  }
+
+  /** Changes the media controls "for" attribute to use an element reference */
+  public async setForElementReference() {
     await this.spectrogram().evaluate((spectrogramElement: SpectrogramComponent) => {
       // We know that the media controls component will exist because we created
       // it in the fixture above.
@@ -52,6 +59,11 @@ class TestPage {
       const mediaControls = document.querySelector("oe-media-controls") as MediaControlsComponent;
       mediaControls.for = spectrogramElement;
     });
+  }
+
+  /** Changes the media controls "for" attribute to use an element id */
+  public async setForElementId() {
+    await setBrowserAttribute<MediaControlsComponent>(this.component(), "for", this.spectrogramId);
   }
 
   public async updateSlot(content: string) {
@@ -94,6 +106,11 @@ class TestPage {
         backgroundColor: styles.backgroundColor,
       };
     });
+  }
+
+  private async waitUntilLoaded() {
+    await waitForContentReady(this.page, ["oe-media-controls", "oe-spectrogram"]);
+    await expect(this.component()).toBeVisible();
   }
 }
 

--- a/src/components/media-controls/media-controls.spec.ts
+++ b/src/components/media-controls/media-controls.spec.ts
@@ -1,49 +1,88 @@
 import { expect } from "../../tests/assertions";
+import { SpectrogramComponent } from "../spectrogram/spectrogram";
+import { MediaControlsComponent } from "./media-controls";
 import { mediaControlsFixture as test } from "./media-controls.fixture";
 
 test.describe("audio element communication", () => {
-  [false, true].forEach((useElementId: boolean) => {
-    test.describe(useElementId ? "using spectrogram id" : "using element reference", () => {
-      test.beforeEach(async ({ fixture }) => {
-        if (useElementId) {
-          await fixture.createWithId();
-        } else {
-          await fixture.createWithRef();
-        }
+  function elementCommunicationTests() {
+    test("should correctly attach a spectrogram component", async ({ fixture }) => {
+      // We use "evaluate" here because we want to compare browser object
+      // references which cannot be reliably passed across the nodejs/browser
+      // Playwright boundary.
+      const hasEqualReference = await fixture.component().evaluate((mediaControls: MediaControlsComponent) => {
+        // I have to use the bracket property access notation because
+        // spectrogramElement is a private field.
+        const internalRef = mediaControls["spectrogramElement"];
+
+        // This type cast here is ok because we are just removing the "null"
+        // typing because we know that the spectrogram exists in the fixture.
+        const spectrogramRef = document.querySelector("oe-spectrogram") as SpectrogramComponent;
+
+        return internalRef === spectrogramRef;
       });
 
-      // this test exists because if you don't correctly import or mount the media controls component
-      // it will still create the element tag, but with no shadow content or error indicating that mounting
-      // the component failed and will make all other tests fail because no content = a "hidden" state
-      // therefore, by having a mounting smoke test, we can ensure that this test will fail only if
-      // we have mounted the component incorrectly
-      test("creating a visible web component", async ({ page }) => {
-        const mediaControls = page.locator("oe-media-controls");
-        await expect(mediaControls).toBeVisible();
-      });
-
-      test("state before interaction", async ({ fixture }) => {
-        const isPlaying = await fixture.isPlayingAudio();
-        expect(isPlaying).toBe(false);
-      });
-
-      test("play functionality", async ({ fixture }) => {
-        await fixture.toggleAudio();
-        const isPlaying = await fixture.isPlayingAudio();
-        expect(isPlaying).toBe(true);
-      });
-
-      test("play pause functionality", async ({ fixture }) => {
-        // start playing audio
-        // by clicking the action button again, we should stop playing audio
-        await fixture.toggleAudio();
-        await fixture.toggleAudio();
-
-        const isPlaying = await fixture.isPlayingAudio();
-
-        expect(isPlaying).toBe(false);
-      });
+      expect(hasEqualReference).toEqual(true);
     });
+
+    // this test exists because if you don't correctly import or mount the media controls component
+    // it will still create the element tag, but with no shadow content or error indicating that mounting
+    // the component failed and will make all other tests fail because no content = a "hidden" state
+    // therefore, by having a mounting smoke test, we can ensure that this test will fail only if
+    // we have mounted the component incorrectly
+    test("creating a visible web component", async ({ page }) => {
+      const mediaControls = page.locator("oe-media-controls");
+      await expect(mediaControls).toBeVisible();
+    });
+
+    test("state before interaction", async ({ fixture }) => {
+      const isPlaying = await fixture.isPlayingAudio();
+      expect(isPlaying).toBe(false);
+    });
+
+    test("play functionality", async ({ fixture }) => {
+      await fixture.toggleAudio();
+      const isPlaying = await fixture.isPlayingAudio();
+      expect(isPlaying).toBe(true);
+    });
+
+    test("play pause functionality", async ({ fixture }) => {
+      // start playing audio
+      // by clicking the action button again, we should stop playing audio
+      await fixture.toggleAudio();
+      await fixture.toggleAudio();
+
+      const isPlaying = await fixture.isPlayingAudio();
+
+      expect(isPlaying).toBe(false);
+    });
+  }
+
+  test.describe("using spectrogram id", () => {
+    test.beforeEach(async ({ fixture }) => {
+      await fixture.createWithId();
+    });
+
+    elementCommunicationTests();
+  });
+
+  test.describe("using element reference", () => {
+    test.beforeEach(async ({ fixture }) => {
+      await fixture.createWithRef();
+    });
+
+    elementCommunicationTests();
+  });
+
+  test("should reflect attribute if changing from spectrogram reference to element id", async ({ fixture }) => {
+    await fixture.createWithId();
+    await fixture.setForElementId();
+    await expect(fixture.component()).toHaveAttribute("for", fixture.spectrogramId);
+  });
+
+  test("should reflect attribute if changing from for attribute to element reference", async ({ fixture }) => {
+    await fixture.createWithRef();
+    await fixture.setForElementReference();
+    await expect(fixture.component()).toHaveAttribute("for", "[object HTMLElement]");
   });
 });
 

--- a/src/components/media-controls/media-controls.spec.ts
+++ b/src/components/media-controls/media-controls.spec.ts
@@ -2,40 +2,48 @@ import { expect } from "../../tests/assertions";
 import { mediaControlsFixture as test } from "./media-controls.fixture";
 
 test.describe("audio element communication", () => {
-  test.beforeEach(async ({ fixture }) => {
-    await fixture.create();
-  });
+  [false, true].forEach((useElementId: boolean) => {
+    test.describe(useElementId ? "using spectrogram id" : "using element reference", () => {
+      test.beforeEach(async ({ fixture }) => {
+        if (useElementId) {
+          await fixture.createWithId();
+        } else {
+          await fixture.createWithRef();
+        }
+      });
 
-  // this test exists because if you don't correctly import or mount the media controls component
-  // it will still create the element tag, but with no shadow content or error indicating that mounting
-  // the component failed and will make all other tests fail because no content = a "hidden" state
-  // therefore, by having a mounting smoke test, we can ensure that this test will fail only if
-  // we have mounted the component incorrectly
-  test("creating a visible web component", async ({ page }) => {
-    const mediaControls = page.locator("oe-media-controls");
-    await expect(mediaControls).toBeVisible();
-  });
+      // this test exists because if you don't correctly import or mount the media controls component
+      // it will still create the element tag, but with no shadow content or error indicating that mounting
+      // the component failed and will make all other tests fail because no content = a "hidden" state
+      // therefore, by having a mounting smoke test, we can ensure that this test will fail only if
+      // we have mounted the component incorrectly
+      test("creating a visible web component", async ({ page }) => {
+        const mediaControls = page.locator("oe-media-controls");
+        await expect(mediaControls).toBeVisible();
+      });
 
-  test("state before interaction", async ({ fixture }) => {
-    const isPlaying = await fixture.isPlayingAudio();
-    expect(isPlaying).toBe(false);
-  });
+      test("state before interaction", async ({ fixture }) => {
+        const isPlaying = await fixture.isPlayingAudio();
+        expect(isPlaying).toBe(false);
+      });
 
-  test("play functionality", async ({ fixture }) => {
-    await fixture.toggleAudio();
-    const isPlaying = await fixture.isPlayingAudio();
-    expect(isPlaying).toBe(true);
-  });
+      test("play functionality", async ({ fixture }) => {
+        await fixture.toggleAudio();
+        const isPlaying = await fixture.isPlayingAudio();
+        expect(isPlaying).toBe(true);
+      });
 
-  test("play pause functionality", async ({ fixture }) => {
-    // start playing audio
-    // by clicking the action button again, we should stop playing audio
-    await fixture.toggleAudio();
-    await fixture.toggleAudio();
+      test("play pause functionality", async ({ fixture }) => {
+        // start playing audio
+        // by clicking the action button again, we should stop playing audio
+        await fixture.toggleAudio();
+        await fixture.toggleAudio();
 
-    const isPlaying = await fixture.isPlayingAudio();
+        const isPlaying = await fixture.isPlayingAudio();
 
-    expect(isPlaying).toBe(false);
+        expect(isPlaying).toBe(false);
+      });
+    });
   });
 });
 
@@ -71,7 +79,7 @@ test.describe("slots", () => {
 
 test.describe("css parts", () => {
   test.beforeEach(async ({ fixture }) => {
-    await fixture.create();
+    await fixture.createWithId();
   });
 
   const cssPartsStyling = `

--- a/src/components/media-controls/media-controls.ts
+++ b/src/components/media-controls/media-controls.ts
@@ -60,7 +60,7 @@ export class MediaControlsComponent extends WithShoelace(AbstractComponent(LitEl
 
   /** A DOM selector to target the spectrogram element */
   @property({ type: String })
-  public for = "";
+  public for: string | SpectrogramComponent = "";
 
   @property({ type: String })
   public playIconPosition: PreferenceLocation = "default";
@@ -125,14 +125,18 @@ export class MediaControlsComponent extends WithShoelace(AbstractComponent(LitEl
       // use add a keydown event listener so that we can bind space bar to play
       document.addEventListener("keydown", this.keyDownHandler);
 
-      // because we want to scope the for attribute to the current shadow root
-      // we need to use the getRootNode method to get the shadow root
-      const rootNode = this.getRootNode() as HTMLElement;
-      const locator = `#${this.for}`;
-      this.spectrogramElement = rootNode.querySelector<SpectrogramComponent>(locator);
+      if (this.for instanceof SpectrogramComponent) {
+        this.spectrogramElement = this.for;
+      } else {
+        // because we want to scope the for attribute to the current shadow root
+        // we need to use the getRootNode method to get the shadow root
+        const rootNode = this.getRootNode() as HTMLElement;
+        const locator = `#${this.for}`;
+        this.spectrogramElement = rootNode.querySelector<SpectrogramComponent>(locator);
+      }
 
       if (!this.spectrogramElement) {
-        console.warn(`Could not locate oe-media-controls target "${locator}"`);
+        console.warn(`Could not locate oe-media-controls target "${this.for}"`);
         return;
       } else if (!(this.spectrogramElement instanceof SpectrogramComponent)) {
         console.error("Attempted to attach oe-media-controls to non spectrogram element");

--- a/src/components/media-controls/media-controls.ts
+++ b/src/components/media-controls/media-controls.ts
@@ -58,8 +58,11 @@ export class MediaControlsComponent extends WithShoelace(AbstractComponent(LitEl
     return null;
   };
 
-  /** A DOM selector to target the spectrogram element */
-  @property({ type: String })
+  /**
+   * A DOM selector or element reference to target the attached spectrogram
+   * element.
+   */
+  @property({ type: String, reflect: true })
   public for: string | SpectrogramComponent = "";
 
   @property({ type: String })


### PR DESCRIPTION
# feat: element ref ability inmedia-controls "for"

## Changes

- Allows the media-controls `for` property to take a `SpectrogramComponent` element reference

Using an element ref should make the Workbench's search page much faster.

## Related Issues

Fixes: #360

## This PR was "TDD Vibe Coded"

This branch was created to test the new [Gemini CLI](https://cloud.google.com/gemini/docs/codeassist/gemini-cli), and see how far I could get by "TDD vibe coding". I just coined the term "TDD vibe coding". I don't know if it's a "formalized" version of "vibe coding", if my term is correct, or if anyone else has written a blog on coding like this.

Turns out, I could complete this issue in 10 minutes.

I originally tried telling Gemini to complete the task with some instructions on what I wanted it to do. It didn't complete the task and went off and started modifying unrelated code.

However, I achieved a much higher success rate if I coded the tests that it needed to pass first, and provided it with some commands to run targeted tests.

I used the following prompt with success. I had to interject twice because it used the wrong playwright command, and tried to re-order an event listener, which would introduce a new bug where the `for` attribute would become disassociated with the internal `spectrogramComponent` reference if assignment hard failed (e.g. in some SSR cases where `document`/`getRoot()` is not defined).

```text
I have written some tests in @src/components/media-controls/media-controls.spec.ts for some functionality that I haven't implemented yet. The media-controls component currently takes a "for" attribute that references an elements id that it is attached to. However, I also want it to take a SpectrogramComponent reference so that I can programatically assign the spectrogram to the media-controls. If you have a solution, run the tests and assert that it works. You should avoid modifying the tests as much as possible.
```

This prompt was my second attempt and took Gemini 36 seconds to complete.

### Limitations

- The Gemini CLI doesn't seem to have access to the language server, so there were some linting mistakes that it couldn't fix without first running the `pnpm lint` command
	- Possible fix: I probably have to configure the Gemini cli to use the `ts-ls` through mcp <https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/configuration.md#available-settings-in-settingsjson>

## Final Checklist

- [x] All commits messages are semver compliant
- [x] Added relevant unit tests for new functionality
- [x] Updated existing unit tests to reflect changes
- [x] Code style is consistent with the project guidelines
- [ ] Documentation is updated to reflect the changes (if applicable)
- [x] Link issues related to the PR
- [x] Assign labels if you have permission
- [x] Assign reviewers if you have permission
- [x] Ensure that CI is passing
- [x] Ensure that `pnpm lint` runs without any errors
- [x] Ensure that `pnpm test` runs without any errors
