### PR TITLE
fix: Do not show tooltips when target expanded

### DIFF
--- a/src/components/verification-grid-tile/verification-grid-tile.ts
+++ b/src/components/verification-grid-tile/verification-grid-tile.ts
@@ -394,7 +394,11 @@ export class VerificationGridTileComponent extends SignalWatcher(WithShoelace(Ab
         <figure class="spectrogram-container vertically-fill ${figureClasses}">
           <div class="figure-head">
             <figcaption class="tag-label">
-              <sl-tooltip content="This item was tagged as '${tagText}' in your data source" placement="bottom-start">
+              <sl-tooltip
+                content="This item was tagged as '${tagText}' in your data source"
+                placement="bottom-start"
+                hoist
+              >
                 <span>${tagText}</span>
               </sl-tooltip>
             </figcaption>

--- a/src/helpers/themes/globalStyles.css
+++ b/src/helpers/themes/globalStyles.css
@@ -78,6 +78,13 @@ sl-tooltip {
   --sl-tooltip-color: var(--oe-font-color);
 }
 
+sl-tooltip:is([aria-expanded="true"]) {
+  &::part(base__popup),
+  &::part(base_arrow) {
+    display: none;
+  }
+}
+
 button:disabled,
 input:disabled {
   filter: grayscale(100%);

--- a/src/helpers/themes/theming.css
+++ b/src/helpers/themes/theming.css
@@ -107,9 +107,9 @@
   );
 
   --oe-panel-color: var(--oe-background-color);
-  --oe-panel-color-light: color-mix(in oklch, var(--oe-panel-color), white 10%);
-  --oe-panel-color-dark: color-mix(in oklch, var(--oe-panel-color), black 3%);
-  --oe-panel-color-darker: color-mix(in oklch, var(--oe-panel-color), black 10%);
+  --oe-panel-color-light: color-mix(in srgb, var(--oe-panel-color), white 10%);
+  --oe-panel-color-dark: color-mix(in srgb, var(--oe-panel-color), black 3%);
+  --oe-panel-color-darker: color-mix(in srgb, var(--oe-panel-color), black 10%);
 
   --oe-undecided-color: var(--oe-panel-color);
   --oe-box-shadow: 1px 1px 1px var(--oe-secondary-color);


### PR DESCRIPTION
# fix: Do not show tooltips when target expanded

When a tooltip was attached to expandable content (e.g. the grid size button menu item), the tooltip could cover content.

This commit fixes this bug so that tooltips are no longer shown when content is expanded in favor of content context (titles) being shown inside the expanded content.

## Changes

- Do not show tooltip if attached to expandable content that is expanded

## Related Issues

Fixes: #405

## Final Checklist

- [ ] All commits messages are semver compliant
- [ ] Added relevant unit tests for new functionality
- [ ] Updated existing unit tests to reflect changes
- [ ] Code style is consistent with the project guidelines
- [ ] Documentation is updated to reflect the changes (if applicable)
- [ ] Link issues related to the PR
- [ ] Assign labels if you have permission
- [ ] Assign reviewers if you have permission
- [ ] Ensure that CI is passing
- [ ] Ensure that `pnpm lint` runs without any errors
- [ ] Ensure that `pnpm test` runs without any errors
