### PR TITLE
fix: Overloaded "loaded" event

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@11ty/eleventy-plugin-syntaxhighlight": "5.0.0",
     "@custom-elements-manifest/analyzer": "0.10.4",
     "@playwright/test": "1.53.1",
-    "@sand4rt/experimental-ct-web": "^1.53.1",
+    "@sand4rt/experimental-ct-web": "1.53.1",
     "@types/audioworklet": "0.0.71",
     "@types/chroma-js": "3.1.1",
     "@types/colorbrewer": "1.0.32",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,7 +61,7 @@ importers:
         specifier: 1.53.1
         version: 1.53.1
       '@sand4rt/experimental-ct-web':
-        specifier: ^1.53.1
+        specifier: 1.53.1
         version: 1.53.1(@types/node@22.13.5)(terser@5.39.0)
       '@types/audioworklet':
         specifier: 0.0.71

--- a/src/components/verification-grid-tile/verification-grid-tile.ts
+++ b/src/components/verification-grid-tile/verification-grid-tile.ts
@@ -61,7 +61,7 @@ const shortcutTranslation = {
  * @cssproperty [--selected-border-size] - The size of the border when a
  * decision is being shown
  *
- * @event Loaded
+ * @event tile-loaded
  */
 @customElement("oe-verification-grid-tile")
 export class VerificationGridTileComponent extends SignalWatcher(WithShoelace(AbstractComponent(LitElement))) {
@@ -249,7 +249,7 @@ export class VerificationGridTileComponent extends SignalWatcher(WithShoelace(Ab
   // this method is called when the spectrogram finishes rendering
   private handleLoaded(): void {
     this.loaded = true;
-    this.dispatchEvent(new CustomEvent("loaded", { bubbles: true }));
+    this.dispatchEvent(new CustomEvent("tile-loaded", { bubbles: true }));
   }
 
   private handleFocusedKeyDown(event: KeyboardEvent): void {

--- a/src/components/verification-grid/verification-grid.ts
+++ b/src/components/verification-grid/verification-grid.ts
@@ -316,7 +316,6 @@ export class VerificationGridComponent extends WithShoelace(AbstractComponent(Li
   private requiredClassificationTags: Tag[] = [];
   private requiredDecisions: RequiredDecision[] = [];
   private hiddenTiles = 0;
-  private decisionsDisabled = false;
   private showingSelectionShortcuts = false;
   private selectionHead: number | null = null;
   private anyOverlap = signal<boolean>(false);
@@ -1267,8 +1266,6 @@ export class VerificationGridComponent extends WithShoelace(AbstractComponent(Li
     for (const decisionElement of decisionElements) {
       decisionElement.disabled = disabled;
     }
-
-    this.decisionsDisabled = disabled;
   }
 
   //#endregion
@@ -1346,15 +1343,11 @@ export class VerificationGridComponent extends WithShoelace(AbstractComponent(Li
     return !gridTilesArray.some((tile: VerificationGridTileComponent) => !tile.loaded);
   }
 
-  private handleSpectrogramLoaded(): void {
-    const decisionsDisabled = this.decisionsDisabled;
-    const loading = !this.areSpectrogramsLoaded();
+  private handleTileLoaded(): void {
+    const loaded = this.areSpectrogramsLoaded();
 
-    if (decisionsDisabled !== loading) {
-      this.setDecisionDisabled(loading);
-    }
-
-    if (!loading) {
+    // If we a spectrogram is loaded
+    if (loaded) {
       // We set the "loaded" property before dispatching the loaded event to
       // minimize the risk of a race condition.
       // E.g. if someone created an event listener for the "grid-loaded" event
@@ -1363,6 +1356,8 @@ export class VerificationGridComponent extends WithShoelace(AbstractComponent(Li
       // event.
       this._loaded = true;
       this.dispatchEvent(new CustomEvent(VerificationGridComponent.loadedEventName));
+
+      this.setDecisionDisabled(false);
     }
   }
 
@@ -1535,7 +1530,7 @@ export class VerificationGridComponent extends WithShoelace(AbstractComponent(Li
                 (subject: SubjectWrapper, i: number) => html`
                   <oe-verification-grid-tile
                     class="grid-tile"
-                    @loaded="${this.handleSpectrogramLoaded}"
+                    @tile-loaded="${() => this.handleTileLoaded()}"
                     @play="${this.handleTilePlay}"
                     .requiredDecisions="${this.requiredDecisions}"
                     .isOnlyTile="${this.populatedTileCount === 1}"

--- a/src/components/verification-grid/verification-grid.ts
+++ b/src/components/verification-grid/verification-grid.ts
@@ -1338,16 +1338,18 @@ export class VerificationGridComponent extends WithShoelace(AbstractComponent(Li
     return Array.from(this.decisionElements ?? []).length > 0;
   }
 
-  private areSpectrogramsLoaded(): boolean {
+  private areTilesLoaded(): boolean {
     const gridTilesArray = Array.from(this.gridTiles);
     return !gridTilesArray.some((tile: VerificationGridTileComponent) => !tile.loaded);
   }
 
   private handleTileLoaded(): void {
-    const loaded = this.areSpectrogramsLoaded();
-
-    // If we a spectrogram is loaded
-    if (loaded) {
+    // This method is run when a tile has completely finished loading.
+    // Therefore, if this loaded event was emitted from the last tile needed to
+    // have a fully loaded verification grid, we want to perform some actions
+    // such as enabling the decision buttons and emitting the verification
+    // grid's "grid-loaded" event.
+    if (this.areTilesLoaded()) {
       // We set the "loaded" property before dispatching the loaded event to
       // minimize the risk of a race condition.
       // E.g. if someone created an event listener for the "grid-loaded" event
@@ -1530,7 +1532,7 @@ export class VerificationGridComponent extends WithShoelace(AbstractComponent(Li
                 (subject: SubjectWrapper, i: number) => html`
                   <oe-verification-grid-tile
                     class="grid-tile"
-                    @tile-loaded="${() => this.handleTileLoaded()}"
+                    @tile-loaded="${this.handleTileLoaded}"
                     @play="${this.handleTilePlay}"
                     .requiredDecisions="${this.requiredDecisions}"
                     .isOnlyTile="${this.populatedTileCount === 1}"

--- a/src/components/verification-grid/verification-grid.ts
+++ b/src/components/verification-grid/verification-grid.ts
@@ -379,7 +379,9 @@ export class VerificationGridComponent extends WithShoelace(AbstractComponent(Li
     // if we were previously lacking the data to fill a verification grid and
     // we just appended more items, we should re-render the verification grid
     // so that the new data can be added
-    this.renderVirtualPage();
+    if (this.hiddenTiles > 0) {
+      this.renderVirtualPage();
+    }
   }
 
   public firstUpdated(): void {


### PR DESCRIPTION
# fix: Overloaded "loaded" event

## Changes

- Changes grid tile's `loaded` event name to `tile-loaded`
- Removes duplicate state for button disabled state

## Related Issues

Fixes: #420

## Final Checklist

- [ ] All commits messages are semver compliant
- [ ] Added relevant unit tests for new functionality
- [ ] Updated existing unit tests to reflect changes
- [ ] Code style is consistent with the project guidelines
- [ ] Documentation is updated to reflect the changes (if applicable)
- [ ] Link issues related to the PR
- [ ] Assign labels if you have permission
- [ ] Assign reviewers if you have permission
- [ ] Ensure that CI is passing
- [ ] Ensure that `pnpm lint` runs without any errors
- [ ] Ensure that `pnpm test` runs without any errors