### PR TITLE
feat: Emit oldSubject in decision-made event

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   ],
   "exports": {
     ".": "./dist/components.js",
-    "./dist/components/*": "./dist/components/*.js"
+    "./dist/components/*": "./dist/components/*.js",
+    "./dist/models/*": "./dist/models/*.js"
   },
   "customElements": "dist/custom-elements.json",
   "dependencies": {

--- a/src/components/verification-grid/verification-grid.ts
+++ b/src/components/verification-grid/verification-grid.ts
@@ -1569,11 +1569,13 @@ export class VerificationGridComponent extends WithShoelace(AbstractComponent(Li
         continue;
       }
 
-      let tileChanges = {};
+      // TODO: Remove this subject copy once we have an finalized spec to
+      // represent the old value of properties that were unset.
+      // see: https://github.com/ecoacoustics/web-components/issues/448
       const oldSubject = Object.assign({}, tile.model);
+      let tileChanges = {};
 
       for (const decision of userDecisions) {
-        // TODO: Remove this subject copy once
         // Skip decisions have some special behavior.
         // If nothing is selected, a skip decision will skip all undecided tiles.
         // If the user does have a subsection, we only apply the skip decision to
@@ -1711,13 +1713,15 @@ export class VerificationGridComponent extends WithShoelace(AbstractComponent(Li
 
     tile.updateSubject(subject);
 
-    // We only dispatch the "decisionWhenUpdated" event after updateSubject so
-    // the risk reading of a race condition is minimized.
-    this.dispatchEvent(
-      new CustomEvent<DecisionMadeEvent>(VerificationGridComponent.decisionMadeEventName, {
-        detail: new Map([[subject, { change, oldSubject }]]),
-      }),
-    );
+    if (Object.keys(change).length > 0) {
+      // We only dispatch the "decisionWhenUpdated" event after updateSubject so
+      // the risk reading of a race condition is minimized.
+      this.dispatchEvent(
+        new CustomEvent<DecisionMadeEvent>(VerificationGridComponent.decisionMadeEventName, {
+          detail: new Map([[subject, { change, oldSubject }]]),
+        }),
+      );
+    }
   }
 
   //#endregion

--- a/src/models/subject.ts
+++ b/src/models/subject.ts
@@ -169,11 +169,24 @@ export class SubjectWrapper {
    */
   public setDecisionNotRequired(decision: Constructor<Decision>): SubjectChange {
     if (decision === Verification) {
+      // We only express that the subject was changed if changing from a
+      // "required" state with a decision to a "not required" state with no
+      // decision.
+      // This means that the SubjectChange describes if a decision was
+      // overwritten as part of setting the decision to "not required".
+      const change: SubjectChange = this.verification === decisionNotRequired || !this.verification
+        ? {}
+        : { verification: decisionNotRequired };
+
       this.verification = decisionNotRequired;
-      return { verification: decisionNotRequired };
+      return change;
     } else if (decision === NewTag) {
+      const change: SubjectChange = this.newTag === decisionNotRequired || !this.newTag
+        ? {}
+        : { newTag: decisionNotRequired };
+
       this.newTag = decisionNotRequired;
-      return { newTag: decisionNotRequired };
+      return change;
     }
 
     return {};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -86,7 +86,7 @@ export default defineConfig({
         "components/tag": "./src/components/tag/tag.ts",
 
         "components/helpers/constants/contextTokens": "./src/helpers/constants/contextTokens.ts",
-        "models/decisionNotRequired": "./src/models/decisions/decisionNotRequired.ts",
+        "models/decisions/decisionNotRequired": "./src/models/decisions/decisionNotRequired.ts",
       },
       formats: ["es"],
     },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -86,6 +86,7 @@ export default defineConfig({
         "components/tag": "./src/components/tag/tag.ts",
 
         "components/helpers/constants/contextTokens": "./src/helpers/constants/contextTokens.ts",
+        "models/decisionNotRequired": "./src/models/decisions/decisionNotRequired.ts",
       },
       formats: ["es"],
     },


### PR DESCRIPTION
# feat: Emit oldSubject in decision-made event

Immediately deprecated upon landing, this property is an escape hatch so when unsetting `newTag`s (or any other property) host applications can use the old value to issue DELETE requests.

This is a hacky solution to a more permanent solution I'd like to discuss in https://github.com/ecoacoustics/web-components/issues/448

## Changes

- `decision-made` values now emit an `oldSubject` property that contains a shallow copy of the `SubjectWrapper` object before any decision modifications were made
- When a decision is **changes** to `unique symbol("no-decision-required")` from an instantiated decision, it now emits a `decision-made` event
- Exports the `noDecisionRequired` symbol as a valid package entrypoint so that consumers can use this symbol in comparisons to see if a decision was updated due to being set to `unique symbol("no-decision-required")`

## Final Checklist

- [ ] All commits messages are semver compliant
- [ ] Added relevant unit tests for new functionality
- [ ] Updated existing unit tests to reflect changes
- [ ] Code style is consistent with the project guidelines
- [ ] Documentation is updated to reflect the changes (if applicable)
- [ ] Link issues related to the PR
- [ ] Assign labels if you have permission
- [ ] Assign reviewers if you have permission
- [ ] Ensure that CI is passing
- [ ] Ensure that `pnpm lint` runs without any errors
- [ ] Ensure that `pnpm test` runs without any errors
