### PR TITLE
feat: Add oe-skip button

### DIFF
--- a/dev/use-cases/ecosounds.html
+++ b/dev/use-cases/ecosounds.html
@@ -22,7 +22,6 @@
       <oe-verification verified="true" shortcut="Y"></oe-verification>
       <oe-verification verified="false" shortcut="N"></oe-verification>
       <oe-verification verified="unsure" shortcut="U"></oe-verification>
-      <oe-verification verified="skip" shortcut="S"></oe-verification>
 
       <oe-tag-prompt
         shortcut="C"

--- a/src/components/decision/skip/skip.ts
+++ b/src/components/decision/skip/skip.ts
@@ -1,0 +1,14 @@
+import { DecisionOptions } from "../../../models/decisions/decision";
+import { VerificationComponent } from "../../decision/verification/verification";
+import { customElement } from "lit/decorators.js";
+
+@customElement("oe-skip")
+export class SkipComponent extends VerificationComponent {
+  public override verified = DecisionOptions.SKIP;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "oe-skip": SkipComponent;
+  }
+}

--- a/src/components/verification-grid/verification-grid.ts
+++ b/src/components/verification-grid/verification-grid.ts
@@ -267,7 +267,7 @@ export class VerificationGridComponent extends WithShoelace(AbstractComponent(Li
 
   // Because it's possible (although unlikely) for multiple skip buttons to
   // exist on a page, this query selector returns an array of elements.
-  @queryAssignedElements({ selector: "oe-verification[verified='skip']" })
+  @queryAssignedElements({ selector: "oe-verification[verified='skip'], oe-skip" })
   private skipButtons!: DecisionComponent[];
 
   @queryDeeplyAssignedElement({ selector: "template" })
@@ -1914,7 +1914,7 @@ export class VerificationGridComponent extends WithShoelace(AbstractComponent(Li
   }
 
   private skipDecisionTemplate(): HTMLTemplateResult {
-    return html`<oe-verification verified="skip" shortcut="s"></oe-verification>`;
+    return html`<oe-skip shortcut="s"></oe-skip>`;
   }
 
   private progressBarTemplate(): HTMLTemplateResult {

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export * from "./components/bootstrap-modal/bootstrap-modal";
 export * from "./components/decision/decision";
 export * from "./components/decision/classification/classification";
 export * from "./components/decision/verification/verification";
+export * from "./components/decision/skip/skip";
 export * from "./components/decision/tag-prompt/tag-prompt";
 export * from "./components/verification-grid-settings/verification-grid-settings";
 export * from "./components/progress-bar/progress-bar";

--- a/src/tests/verification-grid/verification-grid.e2e.fixture.ts
+++ b/src/tests/verification-grid/verification-grid.e2e.fixture.ts
@@ -101,7 +101,10 @@ class TestPage {
 
   private newTagSearchResults = () => this.page.locator(".typeahead-result-action");
 
-  private verificationButton(decision: "true" | "false" | "skip"): Locator {
+  private skipComponent = () => this.page.locator("oe-skip").first();
+  private skipButton = () => this.skipComponent().locator("#decision-button").first();
+
+  private verificationButton(decision: "true" | "false"): Locator {
     const targetDecision = this.page.locator(`oe-verification[verified='${decision}']`).first();
     return targetDecision.locator("#decision-button");
   }
@@ -293,7 +296,7 @@ class TestPage {
   }
 
   public async skipColor(): Promise<string> {
-    return await getCssVariableStyle(this.verificationButton("skip"), "--decision-skip-color", "background");
+    return await getCssVariableStyle(this.skipButton(), "--decision-skip-color", "background");
   }
 
   public async notRequiredColor(): Promise<string> {
@@ -730,8 +733,7 @@ class TestPage {
   }
 
   public async makeSkipDecision() {
-    const decisionButton = this.verificationButton("skip");
-    await decisionButton.click();
+    await this.skipButton().click();
   }
 
   public async viewPreviousHistoryPage() {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -78,6 +78,7 @@ export default defineConfig({
         "components/decision": "./src/components/decision/decision.ts",
         "components/classification": "./src/components/decision/classification/classification.ts",
         "components/verification": "./src/components/decision/verification/verification.ts",
+        "components/skip": "./src/components/decision/skip/skip.ts",
         "components/tag-prompt": "./src/components/decision/tag-prompt/tag-prompt.ts",
         "components/verification-grid-settings": "./src/components/verification-grid-settings/verification-grid-settings.ts",
         "components/progress-bar": "./src/components/progress-bar/progress-bar.ts",


### PR DESCRIPTION
# feat: Add oe-skip button component

This is not a breaking change because you can still use `oe-verification[skip="false"]` but this adds an `oe-skip` component which will stand alone in interfaces and not try to join onto the `oe-verification` button group.

Note that this doesn't fix the squaring issue, but is a quick fix for the sqauring bug on Ecosounds while chipping away at work which we want to do.

## Changes

- Adds standalone `oe-skip` button which does not try to join to other `oe-verification` components

## Related Issues

Fixes: #446

## Visual Changes

<img width="1917" height="1005" alt="image" src="https://github.com/user-attachments/assets/9db6ca4b-943c-49d4-85ba-c1892ef2513e" />

_New `oe-skip` decision button on Ecosounds showing that it fixes visual bugs with new button order_

## Final Checklist

- [ ] All commits messages are semver compliant
- [ ] Added relevant unit tests for new functionality
- [ ] Updated existing unit tests to reflect changes
- [ ] Code style is consistent with the project guidelines
- [ ] Documentation is updated to reflect the changes (if applicable)
- [ ] Link issues related to the PR
- [ ] Assign labels if you have permission
- [ ] Assign reviewers if you have permission
- [ ] Ensure that CI is passing
- [ ] Ensure that `pnpm lint` runs without any errors
- [ ] Ensure that `pnpm test` runs without any errors
