### PR TITLE
fix: contrast for progress bar's undecided color

### DIFF
--- a/src/components/progress-bar/css/style.css
+++ b/src/components/progress-bar/css/style.css
@@ -2,7 +2,7 @@
   display: flex;
   position: relative;
   height: var(--oe-font-size);
-  background-color: var(--oe-panel-color);
+  background-color: var(--oe-panel-color-dark);
   border-radius: var(--oe-border-rounding);
 
   .segment {


### PR DESCRIPTION
# fix: contrast for progress bar's undecided color

When we changed the `--oe-panel-color` to the `--oe-background-color` I didn't correctly adjust the `oe-progress-bar`'s undecided color.

This meant that the "undecided" portion of the progress bar blended perfectly with the background color, making it "invisible".

## Changes

- Use `--oe-panel-color-dark` for progress bars undecided color

## Visual Changes

<img width="1895" height="959" alt="image" src="https://github.com/user-attachments/assets/25f09bc2-1c6a-45d2-90ca-146819fcdb31" />

_Example of the progress bar with "undecided" color. This progress bar shows the "view head", "completed" and "no decision" colors. The no decision color is the small far right hand side color._

If you want me to increase the contrast again, we do have an `--oe-panel-color-darker` which is used in the bootstrap dialog.

## Related Issues

Fixes: #469

## Final Checklist

- [x] All commits messages are semver compliant
- [ ] Added relevant unit tests for new functionality
- [ ] Updated existing unit tests to reflect changes
- [x] Code style is consistent with the project guidelines
- [ ] Documentation is updated to reflect the changes (if applicable)
- [x] Link issues related to the PR
- [x] Assign labels if you have permission
- [x] Assign reviewers if you have permission
- [x] Ensure that CI is passing
- [x] Ensure that `pnpm lint` runs without any errors
- [x] Ensure that `pnpm test` runs without any errors
