### PR TITLE
fix: Skip decisions not showing in progress meter

### DIFF
--- a/dev/use-cases/nsw.html
+++ b/dev/use-cases/nsw.html
@@ -12,8 +12,8 @@
       <oe-verification verified="true" shortcut="Y"></oe-verification>
       <oe-verification verified="false" shortcut="N"></oe-verification>
 
-      <!-- <oe-data-source slot="data-source" for="verification-grid" src="/some-complete.csv" local></oe-data-source> -->
-      <oe-data-source slot="data-source" for="verification-grid" src="/all-complete.csv" local></oe-data-source>
+      <oe-data-source slot="data-source" for="verification-grid" src="/kaleidoscope.csv" local></oe-data-source>
+      <!-- <oe-data-source slot="data-source" for="verification-grid" src="/all-complete.csv" local></oe-data-source> -->
     </oe-verification-grid>
 
     <section id="dev-tools">

--- a/src/components/verification-grid-tile/verification-grid-tile.ts
+++ b/src/components/verification-grid-tile/verification-grid-tile.ts
@@ -242,6 +242,23 @@ export class VerificationGridTileComponent extends SignalWatcher(WithShoelace(Ab
     return change;
   }
 
+  // TODO: The hasVerificationTask, hasNewTagTask and requiredClassificationTags
+  // parameters should be derived from this verification grid tiles model
+  // instead of requiring the verification grid tile to provide them.
+  // By moving these parameters to be derived from the model, we would isolate
+  // the decision meter to this component, meaning that the verification grid
+  // would not need to know about the required decisions for each tile.
+  public skipUndecided(
+    hasVerificationTask: boolean,
+    hasNewTagTask: boolean,
+    requiredClassificationTags: Tag[],
+  ): SubjectChange {
+    const skipChanges = this.model.skipUndecided(hasVerificationTask, hasNewTagTask, requiredClassificationTags);
+    this.requestUpdate();
+
+    return skipChanges;
+  }
+
   private hasAlternativeShortcut(shortcut: string): shortcut is keyof typeof shortcutTranslation {
     return shortcut in shortcutTranslation;
   }

--- a/src/components/verification-grid-tile/verification-grid-tile.ts
+++ b/src/components/verification-grid-tile/verification-grid-tile.ts
@@ -243,7 +243,7 @@ export class VerificationGridTileComponent extends SignalWatcher(WithShoelace(Ab
   }
 
   // TODO: The hasVerificationTask, hasNewTagTask and requiredClassificationTags
-  // parameters should be derived from this verification grid tiles model
+  // parameters should be derived from this verification grid tile's model
   // instead of requiring the verification grid tile to provide them.
   // By moving these parameters to be derived from the model, we would isolate
   // the decision meter to this component, meaning that the verification grid

--- a/src/components/verification-grid/verification-grid.ts
+++ b/src/components/verification-grid/verification-grid.ts
@@ -1936,7 +1936,7 @@ export class VerificationGridComponent extends WithShoelace(AbstractComponent(Li
         // If the user does have a subsection, we only apply the skip decision to
         // the selected tiles.
         if (decision.confirmed === DecisionOptions.SKIP) {
-          const skipChanges = tile.model.skipUndecided(
+          const skipChanges = tile.skipUndecided(
             this.hasVerificationTask(),
             this.hasNewTagTask(),
             this.requiredClassificationTags,

--- a/src/tests/verification-grid/verification-grid.e2e.spec.ts
+++ b/src/tests/verification-grid/verification-grid.e2e.spec.ts
@@ -2110,6 +2110,20 @@ test.describe("decision meter", () => {
       const realizedTooltips = await fixture.progressMeterTooltips();
       expect(realizedTooltips).toEqual(expectedTooltips);
     });
+
+    // Because skip decisions are handled slightly differently and there is a
+    // bit of tech debt from the days when they weren't an actual decision
+    // component, we have seen bugs where only skip decisions fail to show
+    // correctly in the progress meter.
+    test("should show skip decisions correctly", async ({ fixture }) => {
+      await fixture.makeSkipDecision();
+
+      const realizedColors = await fixture.progressMeterColors();
+      expect(realizedColors).toEqual([await fixture.skipColor()]);
+
+      const progressMeterTooltips = await fixture.progressMeterTooltips();
+      expect(progressMeterTooltips).toEqual(["verification: koala (skip)"]);
+    });
   });
 
   test.describe("mixed classification and verification tasks", () => {


### PR DESCRIPTION
# fix: Skip decisions not showing in progress meter

If you used to sub-select multiple tiles, then press "skip" the decision meter would not update correctly. This PR fixes this bug

## Changes

- Fixes bug where pressing "skip" with sub selection wouldn't cause the selected tiles progress meter to update

## Related Issues

Fixes: #494

## Final Checklist

- [x] All commits messages are semver compliant
- [x] Added relevant unit tests for new functionality
- [x] Updated existing unit tests to reflect changes
- [x] Code style is consistent with the project guidelines
- [ ] Documentation is updated to reflect the changes (if applicable)
- [x] Link issues related to the PR
- [x] Assign labels if you have permission
- [x] Assign reviewers if you have permission
- [x] Ensure that CI is passing
- [x] Ensure that `pnpm lint` runs without any errors
- [x] Ensure that `pnpm test` runs without any errors
