### PR TITLE
fix: Removes box shadow for single tile views

### DIFF
--- a/dev/use-cases/shoelace-host-dark.html
+++ b/dev/use-cases/shoelace-host-dark.html
@@ -109,13 +109,13 @@
         --oe-theme-lightness: 51.8% !important;
 
         --oe-font-color: #fff !important;
-        --oe-background-color: rgb(88, 88, 90) !important;
+        --oe-background-color: rgb(45, 45, 46) !important;
 
         --oe-selected-color: rgba(255, 255, 255, 0.1) !important;
 
         --oe-info-bg-color: transparent !important;
 
-        --oe-panel-color: rgb(88, 88, 90) !important;
+        --oe-panel-color: rgb(45, 45, 46) !important;
 
         --oe-border-rounding: 0.2rem !important;
 

--- a/src/components/verification-grid/css/style.css
+++ b/src/components/verification-grid/css/style.css
@@ -74,7 +74,17 @@
   */
   & > .grid-tile {
     border-radius: var(--oe-border-rounding);
-    box-shadow: var(--oe-backdrop-shadow) var(--oe-panel-color-dark);
+  }
+
+  /*
+    The multi-grid styling for grid tiles is in this grid component instead of
+    the verification grid tile component so that everything displayed in the
+    verification grid (including placeholders) has the same styles.
+  */
+  &:not(.singleTileView) {
+    & > .grid-tile {
+      box-shadow: var(--oe-backdrop-shadow) var(--oe-panel-color-dark);
+    }
   }
 
   /*

--- a/src/components/verification-grid/verification-grid.ts
+++ b/src/components/verification-grid/verification-grid.ts
@@ -61,6 +61,7 @@ import { cache } from "lit/directives/cache.js";
 import { templateContent } from "lit/directives/template-content.js";
 import { GridPageFetcher, PageFetcher } from "../../services/gridPageFetcher/gridPageFetcher";
 import { SubjectWriter } from "../../services/subjectWriter/subjectWriter";
+import { classMap } from "lit/directives/class-map.js";
 import verificationGridStyles from "./css/style.css?inline";
 
 export type SelectionObserverType = "desktop" | "tablet" | "default";
@@ -2297,6 +2298,8 @@ export class VerificationGridComponent extends WithShoelace(AbstractComponent(Li
   }
 
   public render() {
+    const gridContainerClasses = classMap({ singleTileView: this.isSingleTileViewMode });
+
     return html`
       <oe-verification-bootstrap
         @open="${this.handleBootstrapDialogOpen}"
@@ -2315,7 +2318,7 @@ export class VerificationGridComponent extends WithShoelace(AbstractComponent(Li
 
         <div
           id="grid-container"
-          class="verification-grid"
+          class="verification-grid ${gridContainerClasses}"
           style="--columns: ${this.columns}; --rows: ${this.rows};"
           @overlap="${this.handleTileOverlap}"
           tabindex="-1"


### PR DESCRIPTION
# fix: Remove box shadow for single tile views

- Removes box shadow for single tile views

## Visual Changes

<img width="1303" height="836" alt="image" src="https://github.com/user-attachments/assets/e9b48b20-9d8e-4392-b1f4-f8716329b5eb" />

_Single tile view without box shadow_

---

<img width="1303" height="786" alt="image" src="https://github.com/user-attachments/assets/72414fe2-c978-4fc6-b394-23ae399bbc9d" />

_unchanged MxN grid with red box shadow for easy viewing_

## Related Issues

Fixes: #517

## Final Checklist

- [ ] All commits messages are semver compliant
- [ ] Added relevant unit tests for new functionality
- [ ] Updated existing unit tests to reflect changes
- [ ] Code style is consistent with the project guidelines
- [ ] Documentation is updated to reflect the changes (if applicable)
- [ ] Link issues related to the PR
- [ ] Assign labels if you have permission
- [ ] Assign reviewers if you have permission
- [ ] Ensure that CI is passing
- [ ] Ensure that `pnpm lint` runs without any errors
- [ ] Ensure that `pnpm test` runs without any errors
