### PR TITLE
fix: Width of top positioned progress bar

### DIFF
--- a/src/components/verification-grid/verification-grid.ts
+++ b/src/components/verification-grid/verification-grid.ts
@@ -2309,7 +2309,7 @@ export class VerificationGridComponent extends WithShoelace(AbstractComponent(Li
       <div id="highlight-box" part="highlight-box"></div>
 
       <div class="verification-container">
-        <div class="controls-container header-controls">
+        <div class="header-controls">
           ${when(this.progressBarPosition === ProgressBarPosition.TOP, () => this.progressBarTemplate())}
         </div>
 


### PR DESCRIPTION
# fix: Width of top positioned progress bar

## Changes

- Fixes top positioned progress bar being too small

## Visual Changes

<img width="1291" height="1005" alt="image" src="https://github.com/user-attachments/assets/14af237d-f1ae-4436-92da-2b7a8d69ff43" />

_Top positioned progress bar + pagination controls_

## Related Issues

Fixes: #508

## Final Checklist

- [ ] All commits messages are semver compliant
- [ ] Added relevant unit tests for new functionality
- [ ] Updated existing unit tests to reflect changes
- [ ] Code style is consistent with the project guidelines
- [ ] Documentation is updated to reflect the changes (if applicable)
- [ ] Link issues related to the PR
- [ ] Assign labels if you have permission
- [ ] Assign reviewers if you have permission
- [ ] Ensure that CI is passing
- [ ] Ensure that `pnpm lint` runs without any errors
- [ ] Ensure that `pnpm test` runs without any errors
