### PR TITLE
fix: Don't render indicator without unit converter

### DIFF
--- a/src/components/indicator/indicator.spec.ts
+++ b/src/components/indicator/indicator.spec.ts
@@ -3,14 +3,26 @@ import { getElementSize } from "../../tests/helpers";
 import { IndicatorComponent } from "./indicator";
 import { indicatorFixture as test } from "./indicator.fixture";
 
-test.describe.skip("Indicator component", () => {
+test.describe("Indicator component", () => {
   test.beforeEach(async ({ fixture }) => {
     await fixture.create();
   });
 
-  test("should be the exact size as its largest direct descendant", async ({ fixture }) => {
+  test.skip("should be the exact size as its largest direct descendant", async ({ fixture }) => {
     const expectedSize = { width: 200, height: 200 };
     const realizedSize = await getElementSize<IndicatorComponent>(fixture.component());
     expect(realizedSize).toEqual(expectedSize);
+  });
+
+  // We used to render the indicator component before the unit converter
+  // initialization, but this caused problems when interacting with component
+  // such as the axes component that only render once the unit converter is
+  // available.
+  // By not rendering anything until the unit converter is available, we avoid
+  // visual layout shifts once the unit converter is initialized.
+  test("should not render if there is no unit converter", async ({ fixture }) => {
+    // By default, this fixture does not create with a unit converter, meaning
+    // that we can just assert that the indicator line is not rendered.
+    await expect(fixture.indicatorLineElement()).toHaveCount(0);
   });
 });

--- a/src/components/indicator/indicator.ts
+++ b/src/components/indicator/indicator.ts
@@ -1,5 +1,5 @@
 import { computed, ReadonlySignal, watch } from "@lit-labs/preact-signals";
-import { html, LitElement, unsafeCSS } from "lit";
+import { html, LitElement, nothing, unsafeCSS } from "lit";
 import { customElement, query } from "lit/decorators.js";
 import { SpectrogramComponent } from "../spectrogram/spectrogram";
 import { UnitConverter } from "../../models/unitConverters";
@@ -75,6 +75,10 @@ export class IndicatorComponent extends ChromeProvider(LitElement) {
   }
 
   public chromeOverlay(): ChromeTemplate {
+    if (!this.unitConverter) {
+      return nothing;
+    }
+
     return html`
       <svg id="indicator-svg">
         <g id="indicator-group" style="transform: translateX(${watch(this.computedTimePx)}px);">

--- a/src/components/indicator/indicator.ts
+++ b/src/components/indicator/indicator.ts
@@ -1,6 +1,6 @@
 import { computed, ReadonlySignal, watch } from "@lit-labs/preact-signals";
 import { html, LitElement, nothing, unsafeCSS } from "lit";
-import { customElement, query } from "lit/decorators.js";
+import { customElement, query, state } from "lit/decorators.js";
 import { SpectrogramComponent } from "../spectrogram/spectrogram";
 import { UnitConverter } from "../../models/unitConverters";
 import { queryDeeplyAssignedElement } from "../../helpers/decorators";
@@ -32,6 +32,7 @@ export class IndicatorComponent extends ChromeProvider(LitElement) {
 
   // TODO: investigate why I am de-referencing the signal here. Wouldn't it be
   // easier to work with and more performant with a reactive signal
+  @state()
   private unitConverter?: UnitConverter;
   private computedTimePx: ReadonlySignal<number> = computed(() => 0);
 


### PR DESCRIPTION
# fix: Don't render indicator without unit converter

This fixes visual jank and layout shift of indicators before spectrograms are rendered.

Check out the "spectrogram creator" on the doc website. You should see less jank on first render.

## Visual Changes

[Screencast from 2025-09-18 15-54-42.webm](https://github.com/user-attachments/assets/254b9838-ea6c-43c9-a102-48e628b91fc5)

_Before changes (with CPU throttling for better viewing)_

---

[Screencast from 2025-09-18 15-56-04.webm](https://github.com/user-attachments/assets/866f7dcb-460b-40a3-9694-dcd23ef3a5f2)

_After changes_

## Limitations

There is still a bit of jank due to #414 (Axes component should reserve space for labels before audio model initialization) which causes the indicator and axes labels to overlap for a single render cycle. (remember that videos above are 20x slower than a typical user, so this jank is present but nearly unnoticeable when at full speed.

## Related Issues

Fixes: #526

## Final Checklist

- [x] All commits messages are semver compliant
- [x] Added relevant unit tests for new functionality
- [x] Updated existing unit tests to reflect changes
- [ ] Code style is consistent with the project guidelines
- [ ] Documentation is updated to reflect the changes (if applicable)
- [x] Link issues related to the PR
- [x] Assign labels if you have permission
- [x] Assign reviewers if you have permission
- [ ] Ensure that CI is passing
- [x] Ensure that `pnpm lint` runs without any errors
- [x] Ensure that `pnpm test` runs without any errors
