### PR TITLE
fix: Use "audacity" as default color map

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ Full page example:
           class="large"
           src="/example.flac"
           window-size="1024"
-          color-map="audacity"
           scaling="stretch"
         ></oe-spectrogram>
       </oe-indicator>

--- a/dev/annotation-edge-cases.html
+++ b/dev/annotation-edge-cases.html
@@ -11,7 +11,7 @@
     <oe-indicator>
       <oe-axes>
         <oe-annotate id="annotate" tag-style="edge">
-          <oe-spectrogram id="spectrogram" src="/example.flac">
+          <oe-spectrogram color-map="grayscale" id="spectrogram" src="/example.flac">
             <source src="/example.flac" />
           </oe-spectrogram>
 

--- a/dev/cherry-picked.html
+++ b/dev/cherry-picked.html
@@ -11,9 +11,8 @@
     <oe-spectrogram src="/example.flac"></oe-spectrogram>
 
     <p>
-      I have purposely cherry picked components that do not require shoelace.
-      On this page, you should not see shoelace or any non-cherry picked
-      components being imported.
+      I have purposely cherry picked components that do not require shoelace. On this page, you should not see shoelace
+      or any non-cherry picked components being imported.
     </p>
   </body>
 </html>

--- a/docs-src/examples/search.md
+++ b/docs-src/examples/search.md
@@ -14,6 +14,7 @@ This example tries to mimic A2O search [search.acousticobservatory.org/search/](
         id="main-spectrogram"
         class="main-spectrogram"
         src="https://api.search.acousticobservatory.org/api/v1/a2o/audio_recordings/download/flac/256800?start_offset=4035&end_offset=4040"
+        color-map="grayscale"
         window-size="128"
       ></oe-spectrogram>
     </oe-indicator>

--- a/src/components/spectrogram/single-spectrogram.fixture.ts
+++ b/src/components/spectrogram/single-spectrogram.fixture.ts
@@ -25,6 +25,7 @@ class TestPage {
         id="spectrogram"
         src="${src}"
         style="position: relative; height: 632px;"
+        color-map="grayscale"
       ></oe-spectrogram>
       <oe-media-controls for="spectrogram"></oe-media-controls>
     `;

--- a/src/components/spectrogram/spectrogram.ts
+++ b/src/components/spectrogram/spectrogram.ts
@@ -70,7 +70,7 @@ export class SpectrogramComponent extends SignalWatcher(ChromeHost(LitElement)) 
     melScale: false,
     brightness: 0,
     contrast: 1,
-    colorMap: "grayscale",
+    colorMap: "audacity",
     scaling: SpectrogramCanvasScale.STRETCH,
   } as const satisfies Required<ISpectrogramOptions>;
 

--- a/src/helpers/audio/colors.ts
+++ b/src/helpers/audio/colors.ts
@@ -76,8 +76,9 @@ export function getColorScale(name: ColorMapName): ColorScaler {
   let scaler = colorScales[name];
 
   if (scaler === undefined) {
-    console.warn(`Could not find color scale "${name}". Defaulting to grayscale`);
-    scaler = colorScales.grayscale;
+    const defaultColorMap = "audacity" satisfies ColorMapName;
+    console.warn(`Could not find color scale "${name}". Defaulting to '${defaultColorMap}'.`);
+    scaler = colorScales[defaultColorMap];
   }
 
   // if scaler is a string, it's a chroma scale


### PR DESCRIPTION
# fix: Use "audacity" as default color map

## Final Checklist

- [ ] All commits messages are semver compliant
- [ ] Added relevant unit tests for new functionality
- [ ] Updated existing unit tests to reflect changes
- [ ] Code style is consistent with the project guidelines
- [ ] Documentation is updated to reflect the changes (if applicable)
- [ ] Link issues related to the PR
- [ ] Assign labels if you have permission
- [ ] Assign reviewers if you have permission
- [ ] Ensure that CI is passing
- [ ] Ensure that `pnpm lint` runs without any errors
- [ ] Ensure that `pnpm test` runs without any errors
