### PR TITLE
docs: Fix A2O search example

### DIFF
--- a/docs-src/examples/search.md
+++ b/docs-src/examples/search.md
@@ -115,6 +115,7 @@ function Spectrogram(id, item) {
   const element = document.createElement("oe-spectrogram");
   element.setAttribute("id", id);
   element.setAttribute("src", item.AudioLink);
+  element.setAttribute("color-map", "grayscale")
   element.className = "search-card-spectrogram";
 
   return element;


### PR DESCRIPTION
# docs: Fix A2O search example

The A2O search example used to use the A2O search API endpoint which is currently unavailable. I have change it so that it now uses the baw-api.

I want to get this working so that I can use it in a bug report to shoelace.

## Changes

- Changes the A2O search endpoint to the baw-api
- Fixes media controls clipping causing click-interactions to fail
- Make card spectrograms grayscale

## Documentation Example

https://68f9a1ea19af115a14c329ac--oe-web-components.netlify.app/examples/search/

## Final Checklist

- [x] All commits messages are semver compliant
- [ ] Added relevant unit tests for new functionality
- [ ] Updated existing unit tests to reflect changes
- [x] Code style is consistent with the project guidelines
- [x] Documentation is updated to reflect the changes (if applicable)
- [x] Link issues related to the PR
- [x] Assign labels if you have permission
- [x] Assign reviewers if you have permission
- [x] Ensure that CI is passing
- [x] Ensure that `pnpm lint` runs without any errors
- [x] Ensure that `pnpm test` runs without any errors
