### PR TITLE
fix: Media controls reflow on creation

### DIFF
--- a/src/components/media-controls/media-controls.ts
+++ b/src/components/media-controls/media-controls.ts
@@ -70,6 +70,19 @@ export class MediaControlsComponent extends WithShoelace(AbstractComponent(LitEl
   @property({ type: String })
   public playIconPosition: PreferenceLocation = "default";
 
+  /**
+   * We use a state variable to track whether the settings menu is open or not
+   * because Shoelace sub-menus use getComputedStyle to determine whether they
+   * are in ltr or rtl mode.
+   * This causes some performance issues when there are a lot of sub-menus or
+   * media controls on the page because each submenu causes a reflow whenever
+   * they are created.
+   * By maintaining our own open/close state we can defer the creation of the
+   * sub-menu contents until the menu is open, meaning that we only hit this
+   * reflow cost when the user actually wants to see the menu.
+   *
+   * see: https://github.com/shoelace-style/shoelace/discussions/2527
+   */
   @state()
   private areSettingsOpen = false;
 


### PR DESCRIPTION
# fix: Media controls reflow on creation

## Changes

- Fixes reflow on media controls creation caused by shoelace sub-menu `getComputedStyle` call
- Conditionally renders the media controls settings menu by using a boolean flag

## Performance tests

<img width="2252" height="1324" alt="image" src="https://github.com/user-attachments/assets/f11d275f-bc1c-4747-81a6-4bff3361808a" />

_Before change_

---

<img width="1685" height="835" alt="image" src="https://github.com/user-attachments/assets/b4f958e1-fb22-44bc-9f23-f792af826d3a" />

_After change_

You can see from the performance metrics above, the A2O search example has gone from ~2,200ms to render to ~1,000ms.

## Related Issues

Fixes: #563

## Final Checklist

- [x] All commits messages are semver compliant
- [ ] Added relevant unit tests for new functionality
- [ ] Updated existing unit tests to reflect changes
- [x] Code style is consistent with the project guidelines
- [ ] Documentation is updated to reflect the changes (if applicable)
- [x] Link issues related to the PR
- [x] Assign labels if you have permission
- [x] Assign reviewers if you have permission
- [x] Ensure that CI is passing
- [x] Ensure that `pnpm lint` runs without any errors
- [x] Ensure that `pnpm test` runs without any errors
