### PR TITLE
fix: empty buffer-builder-processor input

### DIFF
--- a/src/helpers/audio/buffer-builder-processor.ts
+++ b/src/helpers/audio/buffer-builder-processor.ts
@@ -35,7 +35,7 @@ export default class BufferBuilderProcessor extends AudioWorkletProcessor {
     //
     // TypeScript doesn't correctly recognize that indexing into this array
     // might produce undefined, so we need to cast it ourselves.
-    const input = inputs[0][0] as Float32Array<ArrayBufferLike> | undefined;
+    const input = inputs[0][0] as Float32Array | undefined;
 
     // Sometimes the input can receive a zero-length 2d array [[]] on the first
     // call.


### PR DESCRIPTION
# fix: empty buffer-builder-processor input

## Changes

- `buffer-builder-processor` being called with `[[]]` (empty data) now performs a no-op instead of throwing an error `cannot read property of "undefined", reading "length"`

## Related Issues

Fixes: #579

## Final Checklist

- [x] All commits messages are semver compliant
- [ ] Added relevant unit tests for new functionality
- [ ] Updated existing unit tests to reflect changes
- [x] Code style is consistent with the project guidelines
- [ ] Documentation is updated to reflect the changes (if applicable)
- [x] Link issues related to the PR
- [x] Assign labels if you have permission
- [x] Assign reviewers if you have permission
- [ ] Ensure that CI is passing
- [x] Ensure that `pnpm lint` runs without any errors
- [x] Ensure that `pnpm test` runs without any errors
