### PR TITLE
feat: export TypeScript typings as module exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,13 +29,9 @@
       "types": "./@types/index.d.ts",
       "default": "./dist/components.js"
     },
-    "./dist/components/*": {
-      "types": "./@types/components/*.d.ts",
-      "default": "./dist/components/*.js"
-    },
-    "./dist/models/*": {
-      "types": "./@types/models/*.d.ts",
-      "default": "./dist/models/*.js"
+    "./*": {
+      "types": "./@types/*.d.ts",
+      "default": "./dist/*.js"
     }
   },
   "customElements": "dist/custom-elements.json",


### PR DESCRIPTION
# feat: export TypeScript typings as module exports

This means that when you import a JavaScript function / value from our library, TypeScript can automatically find the associated typings file without having to seperately import it.

This is very useful for `moduleResolution: bunlder` used in the new workbench versions.

## Changes

- Exports TypeScript typings in `package.json` `exports`

## Related Issues

Fixes: #582

## Final Checklist

- [x] All commits messages are semver compliant
- [ ] Added relevant unit tests for new functionality
- [ ] Updated existing unit tests to reflect changes
- [x] Code style is consistent with the project guidelines
- [ ] Documentation is updated to reflect the changes (if applicable)
- [x] Link issues related to the PR
- [x] Assign labels if you have permission
- [x] Assign reviewers if you have permission
- [x] Ensure that CI is passing
- [x] Ensure that `pnpm lint` runs without any errors
- [x] Ensure that `pnpm test` runs without any errors
